### PR TITLE
Simple sheets unit test fix

### DIFF
--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
@@ -116,7 +116,7 @@ public class SheetsService {
           }
           valueRow.add(cpsPublisherCount);
           valueRow.add(0);
-          cpsValues.add(valueRow);
+          cpsValues.add(0, valueRow);
           break;
         case CPS_GCLOUD_SUBSCRIBER:
           if (cpsSubscriberCount == 0) { 
@@ -132,7 +132,7 @@ public class SheetsService {
           }
           valueRow.add(kafkaPublisherCount);
           valueRow.add(0);
-          kafkaValues.add(valueRow);
+          kafkaValues.add(0, valueRow);
           break;
         case KAFKA_SUBSCRIBER:
           if (kafkaSubscriberCount == 0) { 

--- a/load-test-framework/src/test/java/com/google/pubsub/flic/output/SheetsServiceTest.java
+++ b/load-test-framework/src/test/java/com/google/pubsub/flic/output/SheetsServiceTest.java
@@ -34,7 +34,7 @@ public class SheetsServiceTest {
       }
     }
     types.put("zone-test", paramsMap);
-    SheetsService service = new SheetsService("", types);
+    SheetsService service = new SheetsService(null, types);
     
     assertEquals(
         service.getCpsPublisherCount() + service.getCpsSubscriberCount(), expectedCpsCount);


### PR DESCRIPTION
Discovered when building from head that the tests still try to authorize access to the user's sheets, which I didn't realize earlier because my branch had it all cached. This simple fix will throw a null pointer when trying to access the credentials file, which is caught by the constructor. Now, the test doesn't try to set up a sheets service, so it doesn't ask for the user to log into their google account.