### PR TITLE
Script fixes

### DIFF
--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -262,6 +262,8 @@ class Driver {
       Client.broker = broker;
       Client.requestRate = requestRate;
       Client.maxOutstandingRequests = maxOutstandingRequests;
+      Client.startTime = Timestamp.newBuilder()
+          .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
       Client.burnInTimeMillis = (Client.startTime.getSeconds() + burnInDurationSeconds) * 1000;
       Client.numberOfMessages = numberOfMessages;
       GCEController gceController = GCEController.newGCEController(
@@ -292,8 +294,6 @@ class Driver {
       int highestRequestRate = 0;
       long backlogSize = 0;
       do {
-        Client.startTime = Timestamp.newBuilder()
-            .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
         Date startDate = new Date();
         startDate.setTime(Client.startTime.getSeconds() * 1000);
         gceController.startClients();

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -262,9 +262,6 @@ class Driver {
       Client.broker = broker;
       Client.requestRate = requestRate;
       Client.maxOutstandingRequests = maxOutstandingRequests;
-      Client.startTime = Timestamp.newBuilder()
-          .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
-      Client.burnInTimeMillis = (Client.startTime.getSeconds() + burnInDurationSeconds) * 1000;
       Client.numberOfMessages = numberOfMessages;
       GCEController gceController = GCEController.newGCEController(
           project, ImmutableMap.of(zone, clientParamsMap),
@@ -294,6 +291,9 @@ class Driver {
       int highestRequestRate = 0;
       long backlogSize = 0;
       do {
+        Client.startTime = Timestamp.newBuilder()
+          .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
+        Client.burnInTimeMillis = (Client.startTime.getSeconds() + burnInDurationSeconds) * 1000;
         Date startDate = new Date();
         startDate.setTime(Client.startTime.getSeconds() * 1000);
         gceController.startClients();

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -292,7 +292,7 @@ class Driver {
       long backlogSize = 0;
       do {
         Client.startTime = Timestamp.newBuilder()
-          .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
+            .setSeconds(System.currentTimeMillis() / 1000 + 90).build();
         Client.burnInTimeMillis = (Client.startTime.getSeconds() + burnInDurationSeconds) * 1000;
         Date startDate = new Date();
         startDate.setTime(Client.startTime.getSeconds() * 1000);

--- a/load-test-framework/src/main/resources/gce/cps-gcloud-java-publisher_startup_script.sh
+++ b/load-test-framework/src/main/resources/gce/cps-gcloud-java-publisher_startup_script.sh
@@ -4,6 +4,7 @@ readonly TMP="$(mktemp -d)"
 [[ "${TMP}" != "" ]] || error mktemp failed
 
 # Download the loadtest binary to this machine and install Java 8.
+/usr/bin/apt-get update
 /usr/bin/apt-get install -y openjdk-8-jre-headless & PIDAPT=$!
 /usr/bin/gsutil cp "gs://cloud-pubsub-loadtest/driver.jar" "${TMP}"
 

--- a/load-test-framework/src/main/resources/gce/cps-gcloud-java-subscriber_startup_script.sh
+++ b/load-test-framework/src/main/resources/gce/cps-gcloud-java-subscriber_startup_script.sh
@@ -4,6 +4,7 @@ readonly TMP="$(mktemp -d)"
 [[ "${TMP}" != "" ]] || error mktemp failed
 
 # Download the loadtest binary to this machine and install Java 8.
+/usr/bin/apt-get update
 /usr/bin/apt-get install -y openjdk-8-jre-headless & PIDAPT=$!
 /usr/bin/gsutil cp "gs://cloud-pubsub-loadtest/driver.jar" "${TMP}"
 

--- a/load-test-framework/src/main/resources/gce/kafka-publisher_startup_script.sh
+++ b/load-test-framework/src/main/resources/gce/kafka-publisher_startup_script.sh
@@ -4,6 +4,7 @@ readonly TMP="$(mktemp -d)"
 [[ "${TMP}" != "" ]] || error mktemp failed
 
 # Download the loadtest binary to this machine and install Java 8.
+/usr/bin/apt-get update
 /usr/bin/apt-get install -y openjdk-8-jre-headless & PIDAPT=$!
 /usr/bin/gsutil cp "gs://cloud-pubsub-loadtest/driver.jar" "${TMP}"
 

--- a/load-test-framework/src/main/resources/gce/kafka-subscriber_startup_script.sh
+++ b/load-test-framework/src/main/resources/gce/kafka-subscriber_startup_script.sh
@@ -4,6 +4,7 @@ readonly TMP="$(mktemp -d)"
 [[ "${TMP}" != "" ]] || error mktemp failed
 
 # Download the loadtest binary to this machine and install Java 8.
+/usr/bin/apt-get update
 /usr/bin/apt-get install -y openjdk-8-jre-headless & PIDAPT=$!
 /usr/bin/gsutil cp "gs://cloud-pubsub-loadtest/driver.jar" "${TMP}"
 


### PR DESCRIPTION
Installing java 8 is failing on all runs of framework due to a change in ubuntu's repository for the jdk. To prevent this from happening again, added apt-get update to the startup scripts.

Also moved creation of Client.startime higher up in the Driver class to avoid null pointer at line 267