### PR TITLE
Don't reference gRPC internal classes

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -19,8 +19,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
 import io.grpc.auth.ClientAuthInterceptor;
-import io.grpc.internal.ManagedChannelImpl;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class ConnectorUtils {
 
   /** Return {@link io.grpc.Channel} which is used by Cloud Pub/Sub gRPC API's. */
   public static Channel getChannel() throws IOException {
-    ManagedChannelImpl channelImpl =
+    ManagedChannel channelImpl =
         NettyChannelBuilder.forAddress(ENDPOINT, 443).negotiationType(NegotiationType.TLS).build();
     final ClientAuthInterceptor interceptor =
         new ClientAuthInterceptor(


### PR DESCRIPTION
Hi, I'm from the gRPC team and it seems like you are referencing a gRPC class that is soon going to be visibility restricted.  This change fixes the code to not have such a reference.