### PR TITLE
Kafka loadtest modifications.

### DIFF
--- a/load-test-framework/flic.iml
+++ b/load-test-framework/flic.iml
@@ -72,7 +72,7 @@
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-compute:v1-rev125-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-storage:v1-rev85-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-monitoring:v3-rev9-1.22.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api-client:google-api-client:1.20.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api-client:google-api-client:1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client:1.20.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.20.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-jackson2:1.20.0" level="project" />
@@ -107,7 +107,7 @@
     <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-common-protos:0.1.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-iam-v1:0.1.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-pubsub-v1:0.1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.apis:google-api-services-sheets:v4-rev32-1.22.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.apis:google-api-services-sheets:v4-rev108-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-java6:1.11.0-beta" level="project" />
     <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-jetty:1.22.0" level="project" />
     <orderEntry type="library" name="Maven: org.mortbay.jetty:jetty:6.1.26" level="project" />

--- a/load-test-framework/pom.xml
+++ b/load-test-framework/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.10</artifactId>
+      <artifactId>kafka_2.11</artifactId>
       <version>0.10.0.0</version>
     </dependency>
     <dependency>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.20.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -133,7 +133,7 @@
     <dependency>
        <groupId>com.google.apis</groupId>
        <artifactId>google-api-services-sheets</artifactId>
-       <version>v4-rev32-1.22.0</version>
+       <version>v4-rev108-1.22.0</version>
      </dependency>
      <dependency>
        <groupId>com.google.oauth-client</groupId>
@@ -144,6 +144,11 @@
        <groupId>com.google.oauth-client</groupId>
        <artifactId>google-oauth-client-jetty</artifactId>
        <version>1.22.0</version>
+     </dependency>
+     <dependency>
+       <groupId>com.101tec</groupId>
+       <artifactId>zkclient</artifactId>
+       <version>0.7</version>
      </dependency>
   </dependencies>
   <build>

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -196,7 +196,7 @@ public class Driver {
       names = {"--zookeeper_ip_address"},
       description = "The network addresses of the Zookeeper clients, comma separated."
   )
-  private String zookeeperIpAddress;
+  private String zookeeperIpAddress = "";
 
   @Parameter(
     names = {"--request_rate"},

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -193,6 +193,13 @@ public class Driver {
   private String broker;
 
   @Parameter(
+      names = {"--zookeeper_ip_address"},
+      description = "The network addresses of the Zookeeper clients, comma separated."
+  )
+
+  private String zookeeperIpAddress;
+
+  @Parameter(
     names = {"--request_rate"},
     description = "The rate at which each client will make requests (batches per second)."
   )
@@ -372,6 +379,11 @@ public class Driver {
           broker != null || (kafkaPublisherCount == 0 && kafkaSubscriberCount == 0),
           "If using Kafka you must provide the network address of your broker using the"
               + "--broker flag.");
+      Preconditions.checkArgument(
+          !(broker != null ^ zookeeperIpAddress != null),
+          "If using Kafka you must provide the network address of your broker using the"
+              + " --broker flag and the network address of your zookeeper hosts using the"
+              + " --zookeeper_ip_address flag.");
 
       if (maxPublishLatencyTest) {
         Preconditions.checkArgument(
@@ -408,6 +420,7 @@ public class Driver {
       Client.maxMessagesPerPull = cpsMaxMessagesPerPull;
       Client.pollDuration = kafkaPollDuration;
       Client.broker = broker;
+      Client.zookeeperIpAddress = zookeeperIpAddress;
       Client.requestRate = requestRate;
       Client.maxOutstandingRequests = maxOutstandingRequests;
       Client.numberOfMessages = numberOfMessages;
@@ -485,6 +498,7 @@ public class Driver {
       new SheetsService(dataStoreDirectory, controller.getTypes())
           .sendToSheets(spreadsheetId, statsMap);
     }
+
     return statsMap;
   }
 

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -196,7 +196,6 @@ public class Driver {
       names = {"--zookeeper_ip_address"},
       description = "The network addresses of the Zookeeper clients, comma separated."
   )
-
   private String zookeeperIpAddress;
 
   @Parameter(
@@ -319,6 +318,20 @@ public class Driver {
   )
   private boolean verbose = false;
 
+  @Parameter(
+      names = {"--replication_factor"},
+      description = "The replication factor to use in creating a Kafka topic, if the Kafka broker"
+          + "is included as a flag."
+  )
+  private int replicationFactor = 2;
+
+  @Parameter(
+      names = {"--partitions"},
+      description = "The number of partitions to use in creating a Kafka topic, if the "
+          + "Kafka broker is included as a flag."
+  )
+  private int partitions = 100;
+
   private Controller controller;
 
   public static void main(String[] args) {
@@ -379,12 +392,6 @@ public class Driver {
           broker != null || (kafkaPublisherCount == 0 && kafkaSubscriberCount == 0),
           "If using Kafka you must provide the network address of your broker using the"
               + "--broker flag.");
-      Preconditions.checkArgument(
-          !(broker != null ^ zookeeperIpAddress != null),
-          "If using Kafka you must provide the network address of your broker using the"
-              + " --broker flag and the network address of your zookeeper hosts using the"
-              + " --zookeeper_ip_address flag.");
-
       if (maxPublishLatencyTest) {
         Preconditions.checkArgument(
             clientParamsMap.size() == 1,
@@ -426,6 +433,8 @@ public class Driver {
       Client.numberOfMessages = numberOfMessages;
       Client.burnInDuration = burnInDuration;
       Client.publishBatchDuration = publishBatchDuration;
+      Client.partitions = partitions;
+      Client.replicationFactor = replicationFactor;
 
       // Start a thread to poll and output results.
       ScheduledExecutorService pollingExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
@@ -59,6 +59,8 @@ public class Client {
   public static int maxOutstandingRequests;
   public static Duration burnInDuration;
   public static int numberOfMessages = 0;
+  public static int replicationFactor;
+  public static int partitions;
   private final ClientType clientType;
   private final String networkAddress;
   private final String project;
@@ -178,13 +180,17 @@ public class Client {
       case KAFKA_PUBLISHER:
         requestBuilder.setKafkaOptions(KafkaOptions.newBuilder()
             .setBroker(broker)
-            .setZookeeperIpAddress(zookeeperIpAddress));
+            .setZookeeperIpAddress(zookeeperIpAddress)
+            .setReplicationFactor(replicationFactor)
+            .setPartitions(partitions));
         break;
       case KAFKA_SUBSCRIBER:
         requestBuilder.setKafkaOptions(KafkaOptions.newBuilder()
             .setBroker(broker)
             .setPollDuration(pollDuration)
-            .setZookeeperIpAddress(zookeeperIpAddress));
+            .setZookeeperIpAddress(zookeeperIpAddress)
+            .setReplicationFactor(replicationFactor)
+            .setPartitions(partitions));
         break;
       case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
       case CPS_GCLOUD_JAVA_PUBLISHER:

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
@@ -55,6 +55,7 @@ public class Client {
   public static int maxMessagesPerPull;
   public static Duration pollDuration;
   public static String broker;
+  public static String zookeeperIpAddress;
   public static int maxOutstandingRequests;
   public static Duration burnInDuration;
   public static int numberOfMessages = 0;
@@ -176,12 +177,14 @@ public class Client {
         break;
       case KAFKA_PUBLISHER:
         requestBuilder.setKafkaOptions(KafkaOptions.newBuilder()
-            .setBroker(broker));
+            .setBroker(broker)
+            .setZookeeperIpAddress(zookeeperIpAddress));
         break;
       case KAFKA_SUBSCRIBER:
         requestBuilder.setKafkaOptions(KafkaOptions.newBuilder()
             .setBroker(broker)
-            .setPollDuration(pollDuration));
+            .setPollDuration(pollDuration)
+            .setZookeeperIpAddress(zookeeperIpAddress));
         break;
       case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
       case CPS_GCLOUD_JAVA_PUBLISHER:
@@ -300,6 +303,24 @@ public class Client {
         case CPS_GCLOUD_JAVA_PUBLISHER:
         case CPS_GCLOUD_PYTHON_PUBLISHER:
         case CPS_VTK_JAVA_PUBLISHER:
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    public boolean isKafkaPublisher() {
+      switch (this) {
+        case KAFKA_PUBLISHER:
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    public boolean isKafkaSubscriber() {
+      switch (this) {
+        case KAFKA_SUBSCRIBER:
           return true;
         default:
           return false;

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
@@ -318,15 +318,6 @@ public class Client {
       }
     }
 
-    public boolean isKafkaSubscriber() {
-      switch (this) {
-        case KAFKA_SUBSCRIBER:
-          return true;
-        default:
-          return false;
-      }
-    }
-
     public boolean isPublisher() {
       switch (this) {
         case CPS_EXPERIMENTAL_JAVA_PUBLISHER:

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
@@ -168,6 +168,9 @@ public class GCEController extends Controller {
             } else {
               log.info("Topic " + topic + " does not exist, no need to delete");
             }
+            while (AdminUtils.topicExists(zookeeperUtils, topic)) {
+              log.info("Waiting for topic to delete...");
+            }
             Properties topicConfig = new Properties();
             AdminUtils
                 .createTopic(zookeeperUtils, topic, 100, 2, AdminUtils.createTopic$default$5(),
@@ -175,19 +178,12 @@ public class GCEController extends Controller {
             log.info("Created topic " + topic);
           } catch (Exception e) {
             kafkaFuture.setException(e);
+            return;
+          } finally {
+            if (zookeeperClient != null) {
+              zookeeperClient.close();
+            }
           }
-
-          /*try {
-            Properties topicConfig = new Properties();
-            AdminUtils
-                .createTopic(zookeeperUtils, topic, 100, 2, AdminUtils.createTopic$default$5(),
-                    AdminUtils.createTopic$default$6());
-            log.info("Created topic " + topic);
-          } catch (Exception e) {
-            log.debug("Exception creating topic", e);
-            kafkaFuture.setException(e);
-            //return;
-          }*/
           kafkaFuture.set(null);
         });
       });

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
@@ -161,7 +161,6 @@ public class GCEController extends Controller {
               log.info("Deleting topic " + topic);
               try {
                 AdminUtils.deleteTopic(zookeeperUtils, topic);
-                log.info("Deleted topic " + topic);
               } catch (ZkNodeExistsException e) {
                 log.info("Topic " + topic + " already marked for delete");
                 kafkaFuture.setException(e);

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
@@ -148,7 +148,8 @@ public class GCEController extends Controller {
     List<SettableFuture<Void>> kafkaFutures = new ArrayList<>();
     // If the Zookeeper host is provided, delete and recreate the topic
     // in order to eliminate performance issues from backlogs.
-    if (Client.zookeeperIpAddress != null) {
+    if (!Client.zookeeperIpAddress.isEmpty()) {
+      log.info("ATTENTION WE R IN TOPIC STUFF FOR KAFKA");
       types.values().forEach(paramsMap -> {
         paramsMap.keySet().stream().map(p -> p.getClientType())
             .distinct().filter(ClientType::isKafkaPublisher).forEach(clientType -> {
@@ -231,8 +232,8 @@ public class GCEController extends Controller {
       // Wait for files and instance groups to be created.
       Futures.allAsList(pubsubFutures).get();
       log.info("Pub/Sub actions completed.");
-      Futures.allAsList(kafkaFutures).get();
-      log.info("Kafka actions completed.");
+      //Futures.allAsList(kafkaFutures).get();
+      //log.info("Kafka actions completed.");
       Futures.allAsList(filesRemaining).get();
       log.info("File uploads completed.");
       Futures.allAsList(createGroupFutures).get();

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
@@ -77,6 +77,8 @@ public class GCEController extends Controller {
       "projects/ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20160930"; // Ubuntu 16.04 LTS
   private static final int ALREADY_EXISTS = 409;
   private static final int NOT_FOUND = 404;
+  private static final int REPLICATION_FACTOR = 2;
+  private static final int PARTITIONS = 100;
   public static String resourceDirectory = "target/classes/gce";
   private final Storage storage;
   private final Compute compute;
@@ -169,11 +171,11 @@ public class GCEController extends Controller {
               log.info("Topic " + topic + " does not exist, no need to delete");
             }
             while (AdminUtils.topicExists(zookeeperUtils, topic)) {
-              log.info("Waiting for topic to delete...");
+              // waiting for topic to delete before recreating
             }
             Properties topicConfig = new Properties();
             AdminUtils
-                .createTopic(zookeeperUtils, topic, 100, 2, AdminUtils.createTopic$default$5(),
+                .createTopic(zookeeperUtils, topic, PARTITIONS, REPLICATION_FACTOR, AdminUtils.createTopic$default$5(),
                     AdminUtils.createTopic$default$6());
             log.info("Created topic " + topic);
           } catch (Exception e) {

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/GCEController.java
@@ -149,7 +149,6 @@ public class GCEController extends Controller {
     // If the Zookeeper host is provided, delete and recreate the topic
     // in order to eliminate performance issues from backlogs.
     if (!Client.zookeeperIpAddress.isEmpty()) {
-      log.info("ATTENTION WE R IN TOPIC STUFF FOR KAFKA");
       types.values().forEach(paramsMap -> {
         paramsMap.keySet().stream().map(p -> p.getClientType())
             .distinct().filter(ClientType::isKafkaPublisher).forEach(clientType -> {
@@ -163,16 +162,16 @@ public class GCEController extends Controller {
                 new ZkConnection(Client.zookeeperIpAddress), false);
             try {
               if (AdminUtils.topicExists(zookeeperUtils, topic)) {
-                log.info("Deleting topic " + topic);
+                log.info("Deleting topic " + topic + ".");
                 try {
                   AdminUtils.deleteTopic(zookeeperUtils, topic);
                 } catch (ZkNodeExistsException e) {
-                  log.info("Topic " + topic + " already marked for delete");
+                  log.info("Topic " + topic + " already marked for delete.");
                   kafkaFuture.setException(e);
                   return;
                 }
               } else {
-                log.info("Topic " + topic + " does not exist, no need to delete");
+                log.info("Topic " + topic + " does not exist.");
               }
               while (AdminUtils.topicExists(zookeeperUtils, topic)) {
                 // waiting for topic to delete before recreating
@@ -182,7 +181,7 @@ public class GCEController extends Controller {
                   .createTopic(zookeeperUtils, topic, Client.partitions, Client.replicationFactor,
                       AdminUtils.createTopic$default$5(),
                       AdminUtils.createTopic$default$6());
-              log.info("Created topic " + topic);
+              log.info("Created topic " + topic + ".");
             } catch (Exception e) {
               kafkaFuture.setException(e);
               return;
@@ -232,8 +231,8 @@ public class GCEController extends Controller {
       // Wait for files and instance groups to be created.
       Futures.allAsList(pubsubFutures).get();
       log.info("Pub/Sub actions completed.");
-      //Futures.allAsList(kafkaFutures).get();
-      //log.info("Kafka actions completed.");
+      Futures.allAsList(kafkaFutures).get();
+      log.info("Kafka actions completed.");
       Futures.allAsList(filesRemaining).get();
       log.info("File uploads completed.");
       Futures.allAsList(createGroupFutures).get();

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
@@ -124,7 +124,6 @@ public class SheetsService {
           new ValueRange().setValues(values.get(1))).setValueInputOption("USER_ENTERED").execute();
     } catch (IOException e) {
       log.error("Error publishing to spreadsheet: " + sheetId);
-      log.error("Here's the exception: " + e);
     }
   }
 
@@ -189,7 +188,7 @@ public class SheetsService {
       valueRow.add(new DecimalFormat("#.##").format(
           (double) LongStream.of(
               stats.bucketValues).sum() / stats.runningSeconds * Client.messageSize / 1000000.0));
-      valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 50.0));   // changed this from 95 to 50 to mirror John's tests
+      valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 50.0));
       valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 99.0));
       valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 99.9));
     });

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
@@ -123,7 +123,7 @@ public class SheetsService {
       service.spreadsheets().values().append(sheetId, "Kafka",
           new ValueRange().setValues(values.get(1))).setValueInputOption("USER_ENTERED").execute();
     } catch (IOException e) {
-      log.error("Error publishing to spreadsheet: " + sheetId);
+      log.error("Error publishing to spreadsheet " + sheetId + ": " + e);
     }
   }
 

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
@@ -74,14 +74,14 @@ public class SheetsService {
       Map<ClientType, Integer> countMap = paramsMap.keySet().stream().
           collect(Collectors.groupingBy(
               ClientParams::getClientType, Collectors.summingInt(t -> 1)));
-      cpsPublisherCount += countMap.get(ClientType.CPS_GCLOUD_JAVA_PUBLISHER);
-      cpsPublisherCount += countMap.get(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER);
-      cpsPublisherCount += countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER);
-      cpsPublisherCount += countMap.get(ClientType.CPS_VTK_JAVA_PUBLISHER);
-      cpsSubscriberCount += countMap.get(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER);
-      cpsSubscriberCount += countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_SUBSCRIBER);
-      kafkaPublisherCount += countMap.get(ClientType.KAFKA_PUBLISHER);
-      kafkaSubscriberCount += countMap.get(ClientType.KAFKA_PUBLISHER);
+      cpsPublisherCount += (countMap.get(ClientType.CPS_GCLOUD_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_GCLOUD_JAVA_PUBLISHER) : 0;
+      cpsPublisherCount += (countMap.get(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER) != null) ? countMap.get(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER) : 0;
+      cpsPublisherCount += (countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER): 0;
+      cpsPublisherCount += (countMap.get(ClientType.CPS_VTK_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_VTK_JAVA_PUBLISHER) : 0;
+      cpsSubscriberCount += (countMap.get(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER) != null) ? countMap.get(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER): 0;
+      cpsSubscriberCount += (countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_SUBSCRIBER) != null) ? countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_SUBSCRIBER): 0;
+      kafkaPublisherCount += (countMap.get(ClientType.KAFKA_PUBLISHER) != null) ? countMap.get(ClientType.KAFKA_PUBLISHER) : 0;
+      kafkaSubscriberCount += (countMap.get(ClientType.KAFKA_SUBSCRIBER) != null) ? countMap.get(ClientType.KAFKA_SUBSCRIBER) : 0;
     });
   }
 
@@ -124,6 +124,7 @@ public class SheetsService {
           new ValueRange().setValues(values.get(1))).setValueInputOption("USER_ENTERED").execute();
     } catch (IOException e) {
       log.error("Error publishing to spreadsheet: " + sheetId);
+      log.error("Here's the exception: " + e);
     }
   }
 
@@ -188,9 +189,9 @@ public class SheetsService {
       valueRow.add(new DecimalFormat("#.##").format(
           (double) LongStream.of(
               stats.bucketValues).sum() / stats.runningSeconds * Client.messageSize / 1000000.0));
-      valueRow.add(LatencyDistribution.getNthPercentile(stats.bucketValues, 95.0));
-      valueRow.add(LatencyDistribution.getNthPercentile(stats.bucketValues, 99.0));
-      valueRow.add(LatencyDistribution.getNthPercentile(stats.bucketValues, 99.9));
+      valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 50.0));   // changed this from 95 to 50 to mirror John's tests
+      valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 99.0));
+      valueRow.add(LatencyDistribution.getNthPercentileMidpoint(stats.bucketValues, 99.9));
     });
     List<List<List<Object>>> out = new ArrayList<>();
     out.add(cpsValues);

--- a/load-test-framework/src/main/proto/loadtest.proto
+++ b/load-test-framework/src/main/proto/loadtest.proto
@@ -86,8 +86,14 @@ message KafkaOptions {
   // The length of time to poll for.
   google.protobuf.Duration poll_duration = 2;
 
-  // The network address(es) of the Zookeeper hosts.
+  // The network address(es) of the Zookeeper host(s).
   string zookeeper_ip_address = 3;
+
+  // The replication factor of the Kafka topic.
+  int32 replication_factor = 4;
+
+  // The number of partitions of the Kafka topic.
+  int32 partitions = 5;
 }
 
 message MessageIdentifier {

--- a/load-test-framework/src/main/proto/loadtest.proto
+++ b/load-test-framework/src/main/proto/loadtest.proto
@@ -85,6 +85,9 @@ message KafkaOptions {
 
   // The length of time to poll for.
   google.protobuf.Duration poll_duration = 2;
+
+  // The network address(es) of the Zookeeper hosts.
+  string zookeeper_ip_address = 3;
 }
 
 message MessageIdentifier {


### PR DESCRIPTION
Kafka topics are now automatically deleted and recreated upon running a loadtest; this ensures no backlog in topics causing performance issues. 
Address of zookeeper hosts will now be a required flag when running a test with Kafka brokers.