### PR TITLE
Client code has been modified to be compatible with jdk1.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+
 matrix:
   include:
     - os: linux
@@ -8,14 +9,9 @@ matrix:
     - os: linux
       jdk: openjdk7
 
-install:
-- mvn -f kafka-connector/pom.xml clean package
-- mvn -f jms-light/pom.xml clean package
-- jdk_switcher use oraclejdk8
-- mvn -f load-test-framework/pom.xml clean package
-#- mvn -f client/pom.xml package
-- jdk_switcher use openjdk7
-
 script:
-- ls
-
+  - mvn -q -B -f jms-light/pom.xml clean verify
+  - mvn -q -B -f kafka-connector/pom.xml clean verify
+  - mvn -q -B -f client/pom.xml clean verify -Dmaven.javadoc.skip=true -Dgpg.skip=true -Djava.util.logging.config.file=client/src/test/resources/logging.properties
+  - jdk_switcher use oraclejdk8
+  - mvn -q -B -f load-test-framework/pom.xml clean verify

--- a/client/src/main/java/com/google/cloud/pubsub/AbstractSubscriberConnection.java
+++ b/client/src/main/java/com/google/cloud/pubsub/AbstractSubscriberConnection.java
@@ -310,7 +310,10 @@ abstract class AbstractSubscriberConnection extends AbstractService {
 
   private void addOutstadingAckHandlers(
       ExpirationInfo expiration, final List<AckHandler> ackHandlers) {
-    outstandingAckHandlers.putIfAbsent(expiration, new ArrayList<AckHandler>(ackHandlers.size()));
+    if (outstandingAckHandlers.get(expiration) == null)
+    {
+      outstandingAckHandlers.put(expiration, new ArrayList<AckHandler>(ackHandlers.size()));
+    }
     outstandingAckHandlers.get(expiration).addAll(ackHandlers);
   }
 

--- a/client/src/test/java/com/google/cloud/pubsub/SubscriberImplTest.java
+++ b/client/src/test/java/com/google/cloud/pubsub/SubscriberImplTest.java
@@ -220,6 +220,8 @@ public class SubscriberImplTest {
 
     // Trigger nack sending
     subscriber.stopAsync().awaitTerminated();
+    // TODO: it's really unstable test and cause of most travis failures. To solve it I decided to use sleep at the time. But we should find a real reason of it or modify requirements.
+    Thread.sleep(200L);
 
     assertEquivalent(
         ImmutableList.of(new ModifyAckDeadline("A", 0)),

--- a/client/src/test/resources/log4j.xml
+++ b/client/src/test/resources/log4j.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true" xmlns:log4j='http://jakarta.apache.org/log4j/'>
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="INFO" />
+    <appender-ref ref="console" />
+  </root>
+</log4j:configuration>

--- a/client/src/test/resources/logging.properties
+++ b/client/src/test/resources/logging.properties
@@ -1,0 +1,5 @@
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tc] [%4$s] [%2$s] %5$s%6$s%n

--- a/jms-light/src/test/resources/logging.properties
+++ b/jms-light/src/test/resources/logging.properties
@@ -1,4 +1,7 @@
+# Logger configuration can be used by passing following param:
 # -Djava.util.logging.config.file=<path_to_config>/logging.properties
+#
+
 # The following creates two handlers
 handlers=java.util.logging.ConsoleHandler
 
@@ -6,7 +9,7 @@ handlers=java.util.logging.ConsoleHandler
 .level=INFO
 
 # Set the default logging level
-java.util.logging.ConsoleHandler.level=FINE
+java.util.logging.ConsoleHandler.level=INFO
 
 # Set the default formatter
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
- _AbstractSubscriberConnection#addOutstadingAckHandlers_ java 1.8 construction (..putIfAbsent) has been replaced with [V v = map.get(key); if (v == null) v = map.put(key, value);](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#putIfAbsent-K-V-)
- _SubscriberImplTest#testReceiverError_NacksMessage_ looks like unstable  and failed in most travis builds.  _Thread.sleep(200)_ helped, better solution should be provided.
- _.travis.yaml_ scripts has been updated with different jdk versions, all projects builds with jdk 1.7/1.8 except 'load-test-framework'