### PR TITLE
add go publisher

### DIFF
--- a/load-test-framework/run.py
+++ b/load-test-framework/run.py
@@ -62,6 +62,9 @@ def main(project, test, client_types, vms_count, broker):
     elif client == 'gcloud_java':
       arg_list.append('--cps_gcloud_java_publisher_count=' + str(vms_count))
       gcloud_subscriber_count += vms_count
+    elif client == 'gcloud_go':
+      arg_list.append('--cps_gcloud_go_publisher_count=' + str(vms_count))
+      gcloud_subscriber_count += vms_count
     elif client == 'vtk':
       arg_list.append('--cps_vtk_java_publisher_count=' + str(vms_count))
       gcloud_subscriber_count += vms_count
@@ -134,7 +137,7 @@ if __name__ == '__main__':
   if len(client_types_arg) == 0:
     client_types_arg = set(['gcloud_java'])
   if not client_types_arg.issubset(
-      set(['gcloud_python', 'gcloud_java', 'vtk', 'experimental'])):
+      set(['gcloud_python', 'gcloud_java', 'gcloud_go', 'vtk', 'experimental'])):
     sys.exit(
         'Invalid --client_type parameter given. Must be a comma deliminated '
         'sequence of client types. Allowed client types are \'gcloud_python\', '

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/adapter/AdapterTask.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/adapter/AdapterTask.java
@@ -42,7 +42,7 @@ public class AdapterTask extends Task {
                 .usePlaintext(true)
                 .build());
     try {
-      stub.start(request);
+      stub.start(request).get();
     } catch (Throwable t) {
       throw new RuntimeException("Unable to start server.", t);
     }

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/Driver.java
@@ -119,6 +119,12 @@ public class Driver {
   private int cpsGcloudPythonPublisherCount = 0;
 
   @Parameter(
+    names = {"--cps_gcloud_go_publisher_count"},
+    description = "Number of CPS publishers of this type to start."
+  )
+  private int cpsGcloudGoPublisherCount = 0;
+
+  @Parameter(
     names = {"--kafka_publisher_count"},
     description = "Number of Kafka publishers to start."
   )
@@ -363,6 +369,11 @@ public class Driver {
             new ClientParams(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER, null),
             cpsGcloudPythonPublisherCount);
       }
+      if (cpsGcloudGoPublisherCount > 0) {
+        clientParamsMap.put(
+            new ClientParams(ClientType.CPS_GCLOUD_GO_PUBLISHER, null),
+            cpsGcloudGoPublisherCount);
+      }
       if (cpsExperimentalJavaPublisherCount > 0) {
         clientParamsMap.put(
             new ClientParams(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER, null),
@@ -402,9 +413,9 @@ public class Driver {
       for (int i = 0; i < cpsSubscriptionFanout; ++i) {
         if (cpsGcloudJavaSubscriberCount > 0) {
           Preconditions.checkArgument(
-              cpsGcloudJavaPublisherCount + cpsGcloudPythonPublisherCount + cpsVtkJavaPublisherCount
+              cpsGcloudJavaPublisherCount + cpsGcloudPythonPublisherCount + cpsVtkJavaPublisherCount + cpsGcloudGoPublisherCount
                   > 0,
-              "--cps_gcloud_java_publisher or --cps_gcloud_python_publisher must be > 0.");
+              "--cps_gcloud_java_publisher, --cps_gcloud_go_publisher, or --cps_gcloud_python_publisher must be > 0.");
           clientParamsMap.put(
               new ClientParams(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER, "gcloud-subscription" + i),
               cpsGcloudJavaSubscriberCount / cpsSubscriptionFanout);

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
@@ -110,6 +110,7 @@ public class Client {
       case CPS_GCLOUD_JAVA_PUBLISHER:
       case CPS_GCLOUD_JAVA_SUBSCRIBER:
       case CPS_GCLOUD_PYTHON_PUBLISHER:
+      case CPS_GCLOUD_GO_PUBLISHER:
         return "gcloud";
       case CPS_VTK_JAVA_PUBLISHER:
         return "vtk";
@@ -195,6 +196,7 @@ public class Client {
       case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
       case CPS_GCLOUD_JAVA_PUBLISHER:
       case CPS_GCLOUD_PYTHON_PUBLISHER:
+      case CPS_GCLOUD_GO_PUBLISHER:
       case CPS_VTK_JAVA_PUBLISHER:
         break;
     }
@@ -299,6 +301,7 @@ public class Client {
     CPS_GCLOUD_JAVA_PUBLISHER,
     CPS_GCLOUD_JAVA_SUBSCRIBER,
     CPS_GCLOUD_PYTHON_PUBLISHER,
+    CPS_GCLOUD_GO_PUBLISHER,
     CPS_VTK_JAVA_PUBLISHER,
     KAFKA_PUBLISHER,
     KAFKA_SUBSCRIBER;
@@ -308,6 +311,7 @@ public class Client {
         case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
         case CPS_GCLOUD_JAVA_PUBLISHER:
         case CPS_GCLOUD_PYTHON_PUBLISHER:
+        case CPS_GCLOUD_GO_PUBLISHER:
         case CPS_VTK_JAVA_PUBLISHER:
           return true;
         default:
@@ -329,6 +333,7 @@ public class Client {
         case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
         case CPS_GCLOUD_JAVA_PUBLISHER:
         case CPS_GCLOUD_PYTHON_PUBLISHER:
+        case CPS_GCLOUD_GO_PUBLISHER:
         case CPS_VTK_JAVA_PUBLISHER:
         case KAFKA_PUBLISHER:
           return true;
@@ -343,6 +348,7 @@ public class Client {
           return CPS_EXPERIMENTAL_JAVA_SUBSCRIBER;
         case CPS_GCLOUD_JAVA_PUBLISHER:
         case CPS_GCLOUD_PYTHON_PUBLISHER:
+        case CPS_GCLOUD_GO_PUBLISHER:
         case CPS_VTK_JAVA_PUBLISHER:
           return CPS_GCLOUD_JAVA_SUBSCRIBER;
         case KAFKA_PUBLISHER:

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/SheetsService.java
@@ -76,6 +76,7 @@ public class SheetsService {
               ClientParams::getClientType, Collectors.summingInt(t -> 1)));
       cpsPublisherCount += (countMap.get(ClientType.CPS_GCLOUD_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_GCLOUD_JAVA_PUBLISHER) : 0;
       cpsPublisherCount += (countMap.get(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER) != null) ? countMap.get(ClientType.CPS_GCLOUD_PYTHON_PUBLISHER) : 0;
+      cpsPublisherCount += (countMap.get(ClientType.CPS_GCLOUD_GO_PUBLISHER) != null) ? countMap.get(ClientType.CPS_GCLOUD_GO_PUBLISHER) : 0;
       cpsPublisherCount += (countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_EXPERIMENTAL_JAVA_PUBLISHER): 0;
       cpsPublisherCount += (countMap.get(ClientType.CPS_VTK_JAVA_PUBLISHER) != null) ? countMap.get(ClientType.CPS_VTK_JAVA_PUBLISHER) : 0;
       cpsSubscriberCount += (countMap.get(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER) != null) ? countMap.get(ClientType.CPS_GCLOUD_JAVA_SUBSCRIBER): 0;
@@ -137,6 +138,7 @@ public class SheetsService {
         case CPS_EXPERIMENTAL_JAVA_PUBLISHER:
         case CPS_GCLOUD_JAVA_PUBLISHER:
         case CPS_GCLOUD_PYTHON_PUBLISHER:
+        case CPS_GCLOUD_GO_PUBLISHER:
         case CPS_VTK_JAVA_PUBLISHER:
           if (cpsPublisherCount == 0) {
             return;

--- a/load-test-framework/src/main/resources/gce/cps-gcloud-go-publisher_startup_script.sh
+++ b/load-test-framework/src/main/resources/gce/cps-gcloud-go-publisher_startup_script.sh
@@ -1,0 +1,38 @@
+#/bin/bash
+
+#######################################
+# Query GCE for a provided metadata field.
+# See https://developers.google.com/compute/docs/metadata
+# Globals:
+#   None
+# Arguments:
+#   $1: The path to the metadata field to retrieve
+# Returns:
+#   The value stored at the metadata field
+#######################################
+function metadata() {
+  curl --silent --show-error --header 'Metadata-Flavor: Google' \
+    "http://metadata/computeMetadata/v1/${1}";
+}
+
+readonly TMP="$(mktemp -d)"
+readonly BUCKET=$(metadata instance/attributes/bucket)
+
+[[ "${TMP}" != "" ]] || error mktemp failed
+
+# Download the loadtest binary to this machine and install Java 8.
+/usr/bin/apt-get update
+/usr/bin/apt-get install -y openjdk-8-jre-headless &
+/usr/bin/gsutil cp "gs://${BUCKET}/driver.jar" "${TMP}" &
+/usr/bin/gsutil cp "gs://${BUCKET}/loadtest-go" "${TMP}" &
+
+wait
+
+cd ${TMP}
+chmod +x loadtest-go
+./loadtest-go & PIDSERV=$!
+
+# Run the loadtest binary
+java -Xmx5000M -cp driver.jar com.google.pubsub.clients.adapter.PublisherAdapterTask
+
+kill $PIDSERV


### PR DESCRIPTION
This PR also fixes a race in AdapterTask.
Previously it issues a StartRequest to the worker process without
waiting for the RPC to complete.
Consequently, the load test might happen before the worker process
could process the StartRequest.
This is fixed by making AdapterTask wait for the request to return.

The Go support is incomplete.
The program expects the binary to be available at gs://BUCKET/loadtest-go,
but does not automatically upload it there.
If possible, I'd like to land this automation in a separate PR to unblock my work
on load testing Go subscriber implementation.

cc @jba