### PR TITLE
Trivial change (added an empty line) to triger travis test.

### DIFF
--- a/jms-light/pom.xml
+++ b/jms-light/pom.xml
@@ -6,6 +6,7 @@
   <version>1.0-SNAPSHOT</version>
   <name>Google Cloud Pub/Sub JMS client</name>
 
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>


### PR DESCRIPTION
DO NOT MERGE THIS PULL REQUEST!

Given the for me unexplainable test errors for my recent pull requests I just want to trigger another travis test run with minimal changes that cannot possibly cause a new test failure. This is to show that the current code base in the master branch is already "broken" (does not pass the tests).

When running the client/pom.xml configuration locally, although maven says all tests passed there is a huge list of stack traces. I do not know if this is a problem, but at the very least it does not look clean to me.

I expect the tests only to fail with the Oracle JDK 8. I have the impression that there is an incompatibility with this particular JDK.