### PR TITLE
Replace PubSubTopic class with existing PubSubTopicDestination class

### DIFF
--- a/jms-light/src/main/java/com/google/pubsub/jms/light/PubSubTopic.java
+++ b/jms-light/src/main/java/com/google/pubsub/jms/light/PubSubTopic.java
@@ -1,7 +1,0 @@
-package com.google.pubsub.jms.light;
-
-/**
- * Default PubSub {@link javax.jms.Topic} implementation.
- */
-public class PubSubTopic {
-}

--- a/jms-light/src/test/java/com/google/pubsub/jms/light/publisher/GeneralTopicTest.java
+++ b/jms-light/src/test/java/com/google/pubsub/jms/light/publisher/GeneralTopicTest.java
@@ -5,10 +5,10 @@ import com.google.pubsub.jms.light.PubSubConnectionFactory;
 import com.google.pubsub.jms.light.PubSubSession;
 import com.google.pubsub.jms.light.PubSubMessageConsumer;
 import com.google.pubsub.jms.light.PubSubMessageProducer;
-import com.google.pubsub.jms.light.PubSubTopic;
 import com.google.pubsub.jms.light.PubSubTopicConnection;
 import com.google.pubsub.jms.light.PubSubTopicSession;
 import com.google.pubsub.jms.light.destination.PubSubDestination;
+import com.google.pubsub.jms.light.destination.PubSubTopicDestination;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -46,8 +46,8 @@ public class GeneralTopicTest extends AbstractJMSTest {
         Assert.assertTrue(Connection.class.isAssignableFrom(PubSubConnection.class));
         Assert.assertTrue(TopicConnection.class.isAssignableFrom(PubSubTopicConnection.class));
         Assert.assertTrue(PubSubConnection.class.isAssignableFrom(PubSubTopicConnection.class));
-        Assert.assertTrue(Topic.class.isAssignableFrom(PubSubTopic.class));
-        Assert.assertTrue(PubSubDestination.class.isAssignableFrom(PubSubTopic.class));
+        Assert.assertTrue(Topic.class.isAssignableFrom(PubSubTopicDestination.class));
+        Assert.assertTrue(PubSubDestination.class.isAssignableFrom(PubSubTopicDestination.class));
         Assert.assertTrue(Destination.class.isAssignableFrom(PubSubDestination.class));
         Assert.assertTrue(Session.class.isAssignableFrom(PubSubSession.class));
         Assert.assertTrue(TopicSession.class.isAssignableFrom(PubSubTopicSession.class));


### PR DESCRIPTION
#66 

The PubSubTopic class has already been implemented as PubSubTopicDestination in com.google.pubsub.jms.light.destination.

Replacing the PubSubTopic class with PubSubTopicDestination class in test.