### PR TITLE
Xlint Configuration

### DIFF
--- a/jms-light/pom.xml
+++ b/jms-light/pom.xml
@@ -20,9 +20,7 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
+          <compilerArgument>-Xlint:all</compilerArgument>
         </configuration>
       </plugin>
 

--- a/jms-light/src/main/java/com/google/pubsub/jms/light/message/PubSubTextMessage.java
+++ b/jms-light/src/main/java/com/google/pubsub/jms/light/message/PubSubTextMessage.java
@@ -29,14 +29,14 @@ public class PubSubTextMessage extends AbstractPubSubMessage implements TextMess
 
   @Override
   public <T> T getBody(final Class<T> clazz) throws JMSException {
-    final String result;
+    final T result;
     if (isBodyAssignableTo(clazz)) {
-      result = getText();
+      result = clazz.cast(getText());
     } else {
       throw new MessageFormatException("Can't be assigned to " + clazz);
     }
 
-    return (T) result; 
+    return result; 
   }
 
   @Override


### PR DESCRIPTION
This is the configuration that I used. With this, I get the following warnings (the second one is probably independent of -Xlint):

...
[WARNING] /usr/local/google/home/uhu/src/pubsub/jms-light/src/main/java/com/google/pubsub/jms/light/message/PubSubTextMessage.java:[39,16] unchecked cast
  required: T
  found:    java.lang.String
...
[WARN] /usr/local/google/home/uhu/src/pubsub/jms-light/src/main/java/com/google/pubsub/jms/light/PubSubTopicSession.java:9: Wrong lexicographical order for 'com.google.pubsub.jms.light.destination.PubSubTemporaryTopic' import. Should be before 'javax.jms.TemporaryTopic'. [CustomImportOrder]
[WARN] /usr/local/google/home/uhu/src/pubsub/jms-light/src/main/java/com/google/pubsub/jms/light/PubSubTopicConnectionFactory.java:12: Line is longer than 100 characters (found 109). [LineLength]
[WARN] /usr/local/google/home/uhu/src/pubsub/jms-light/src/main/java/com/google/pubsub/jms/light/PubSubTopicConnectionFactory.java:20: Line is longer than 100 characters (found 114). [LineLength]