### PR TITLE
Adding ${os.detected.classifier} to Pom

### DIFF
--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -27,7 +27,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>1.1.33.Fork14</version>
-      <classifier>linux-x86_64</classifier>
+      <classifier>${os.detected.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>


### PR DESCRIPTION
Just adding ${os.detected.classifier} to Pom so the right netty-tcnative-boring-ssl-static library is selected.
This is to ensure the connector can work in any OS (e.g. OSX).