### PR TITLE
Shade the guava library to avoid a NoMethodFoundError 

### DIFF
--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -106,6 +106,7 @@
               <artifactSet>
                 <excludes>
                   <exclude>com.fasterxml.jackson.core:jackson-core:jar:*</exclude>
+		  <exclude>com.google.guava:*</exclude>
                 </excludes>
               </artifactSet>
               <transformers>


### PR DESCRIPTION
A slightly better approach than PR #115, which adds the (unneeded) guava dependency.