### PR TITLE
increase parallel puller count

### DIFF
--- a/load-test-framework/pom.xml
+++ b/load-test-framework/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>0.21.1-beta</version>
+      <version>0.24.0-beta</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
@@ -39,10 +39,13 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
 
   private CPSSubscriberTask(StartRequest request) {
     super(request, "gcloud", MetricsHandler.MetricName.END_TO_END_LATENCY);
-    this.subscription = SubscriptionName.create(
-        request.getProject(), request.getPubsubOptions().getSubscription());
+    this.subscription =
+        SubscriptionName.create(request.getProject(), request.getPubsubOptions().getSubscription());
     try {
-      this.subscriber = Subscriber.defaultBuilder(this.subscription, this).build();
+      this.subscriber =
+          Subscriber.defaultBuilder(this.subscription, this)
+              .setParallelPullCount(Runtime.getRuntime().availableProcessors() * 5)
+              .build();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
The new default number of parallel pullers is NumCPU.
To keep up with publishers, we need to increase the number of pullers.
This commit increaes the number to 5*NumCPU,
the same as the old default.