### PR TITLE
java: don't sync on shutdown

### DIFF
--- a/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
@@ -82,8 +82,6 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
 
   @Override
   public void shutdown() {
-    synchronized (this) {
-      subscriber.stopAsync().awaitTerminated();
-    }
+    subscriber.stopAsync().awaitTerminated();
   }
 }

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
@@ -36,11 +36,12 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
   private static final Logger log = LoggerFactory.getLogger(CPSSubscriberTask.class);
   private final SubscriptionName subscription;
   private Subscriber subscriber;
+  private boolean shuttingDown = false;
 
   private CPSSubscriberTask(StartRequest request) {
     super(request, "gcloud", MetricsHandler.MetricName.END_TO_END_LATENCY);
-    this.subscription = SubscriptionName.create(
-        request.getProject(), request.getPubsubOptions().getSubscription());
+    this.subscription =
+        SubscriptionName.create(request.getProject(), request.getPubsubOptions().getSubscription());
     try {
       this.subscriber = Subscriber.defaultBuilder(this.subscription, this).build();
     } catch (Exception e) {
@@ -69,6 +70,10 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
       if (subscriber.isRunning()) {
         return Futures.immediateFuture(RunResult.empty());
       }
+      if (shuttingDown) {
+        return Futures.immediateFailedFuture(
+            new IllegalStateException("the task is shutting down"));
+      }
       try {
         subscriber.startAsync().awaitRunning();
       } catch (Exception e) {
@@ -82,6 +87,16 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
 
   @Override
   public void shutdown() {
+    Subscriber subscriber;
+    synchronized (this) {
+      if (shuttingDown) {
+        throw new IllegalStateException("the task is already shutting down");
+      }
+      shuttingDown = true;
+      subscriber = this.subscriber;
+    }
+    // We must stop out of the lock. Stopping waits for all messages to be processed,
+    // and processing the messages needs to lock.
     subscriber.stopAsync().awaitTerminated();
   }
 }


### PR DESCRIPTION
Shutting down needs to wait for messages to be processed,
and processing the messages need to lock the Task object.
So, if the thread calling shutdown locks the Task object, we'll
deadlock.