### PR TITLE
No duplicates in Kafka when ack fails

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -46,7 +46,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A {@link SourceTask} used by a {@link CloudPubSubSourceConnector} to write messages to <a
- * href="http://kafka.apache.org/">Apache Kafka</a>.
+ * href="http://kafka.apache.org/">Apache Kafka</a>. Due to at-last-once semantics in Google
+ * Cloud Pub/Sub duplicates in Kafka are possible.
  */
 public class CloudPubSubSourceTask extends SourceTask {
 

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -121,7 +121,8 @@ public class CloudPubSubSourceTask extends SourceTask {
         PubsubMessage message = rm.getMessage();
         String ackId = rm.getAckId();
         // If we are receiving this message a second (or more) times because the ack for it failed
-        // then do not create a SourceRecord for this message. In case we are waiting for ack response we also skip the message
+        // then do not create a SourceRecord for this message. In case we are waiting for ack
+        // response we also skip the message
         if (ackIds.contains(ackId) || ackIdsInFlight.contains(ackId)) {
           continue;
         }

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -147,7 +147,7 @@ public class CloudPubSubSourceTaskTest {
 
 
   /**
-   * Tests that when a call to ackMessages() fails, that the message is redelivered to Kafka if
+   * Tests that when a call to ackMessages() fails, that the message is not redelivered to Kafka if
    * the message is received again by Cloud Pub/Sub. Also tests that ack ids are added properly if
    * the ack id has not been seen before.
    */
@@ -166,7 +166,7 @@ public class CloudPubSubSourceTaskTest {
     ListenableFuture<Empty> failedFuture = Futures.immediateFailedFuture(new Throwable());
     when(subscriber.ackMessages(any(AcknowledgeRequest.class))).thenReturn(failedFuture);
     result = task.poll();
-    assertEquals(2, result.size());
+    assertEquals(1, result.size());
     verify(subscriber, times(1)).ackMessages(any(AcknowledgeRequest.class));
 
   }


### PR DESCRIPTION
The idea is not to produce duplicates in Kafka if Pub/sub ack fails. We can achieve that by managing ack ids in callbacks.