### PR TITLE
Acknowledge Cloud Pub/Sub messages in commit hook

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -107,7 +107,6 @@ public class CloudPubSubSourceTask extends SourceTask {
   @Override
   public List<SourceRecord> poll() throws InterruptedException {
     log.debug("Polling...");
-    ackMessages();
     PullRequest request =
         PullRequest.newBuilder()
             .setSubscription(cpsSubscription)
@@ -190,6 +189,11 @@ public class CloudPubSubSourceTask extends SourceTask {
       log.info("Error while retrieving records, treating as an empty poll. " + e);
       return new ArrayList<>();
     }
+  }
+
+  @Override
+  public void commit() throws InterruptedException {
+    ackMessages();
   }
 
   /**

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -139,8 +139,10 @@ public class CloudPubSubSourceTaskTest {
     when(subscriber.ackMessages(any(AcknowledgeRequest.class))).thenReturn(goodFuture);
     when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
     result = task.poll();
+    task.commit();
     assertEquals(0, result.size());
     result = task.poll();
+    task.commit();
     assertEquals(0, result.size());
     verify(subscriber, times(1)).ackMessages(any(AcknowledgeRequest.class));
   }
@@ -163,12 +165,8 @@ public class CloudPubSubSourceTaskTest {
     stubbedPullResponse =
         PullResponse.newBuilder().addReceivedMessages(0, rm1).addReceivedMessages(1, rm2).build();
     when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
-    ListenableFuture<Empty> failedFuture = Futures.immediateFailedFuture(new Throwable());
-    when(subscriber.ackMessages(any(AcknowledgeRequest.class))).thenReturn(failedFuture);
     result = task.poll();
     assertEquals(1, result.size());
-    verify(subscriber, times(1)).ackMessages(any(AcknowledgeRequest.class));
-
   }
 
   /**


### PR DESCRIPTION
Current implementation acks pub/sub messages in the beginning of pull method which means that it takes two pull cycles to send messages to Kafka and acknowledge them after. Whenever you stop Kafka connector, the messages from the last cycle would get delivered to Kafka but acknowledge of pub/sub messages would not happen. This produces ( cps.maxBatchSize * tasks.max) duplicates on every stop of Kafka connector. 
Provided implementation uses SourceTask commit hook to acknowledge pub/sub messages.