### PR TITLE
Configurable converter to support different serialization formats

### DIFF
--- a/kafka-connector/config/cps-sink-connector.properties
+++ b/kafka-connector/config/cps-sink-connector.properties
@@ -4,3 +4,5 @@ tasks.max=10
 topics=my-kafka-topic
 cps.topic=my-cps-topic
 cps.project=my-cps-project
+value.converter=com.google.pubsub.kafka.sink.CloudPubSubSinkConnectorTest$SillyStringConverter
+value.converter.prefix=somePrefix_

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -41,6 +41,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final int DEFAULT_MAX_BUFFER_SIZE = 100;
   public static final String CPS_MESSAGE_BODY_NAME = "messageBodyName";
   public static final String DEFAULT_MESSAGE_BODY_NAME = "cps_message_body";
+  public static final String VALUE_CONVERTER = "value.converter";
   private Map<String, String> props;
 
   @Override
@@ -96,7 +97,14 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             DEFAULT_MESSAGE_BODY_NAME,
             Importance.MEDIUM,
             "When using a struct or map value schema, this field or key name indicates that the "
-                + "corresponding value will go into the Pub/Sub message body.");
+                + "corresponding value will go into the Pub/Sub message body.")
+        .define(VALUE_CONVERTER,
+            Type.STRING,
+            null,
+            Importance.MEDIUM,
+            "Converter class to be used for converting between Kafka Connect Record and data written to Kafka. " +
+                    "This makes converter logic completely decoupled from specific Connector and supporting any " +
+                    "serialization format. Some of the examples are Json/Avro converters.");
   }
 
   @Override

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -33,16 +33,21 @@ import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import junit.framework.Assert;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.Converter;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -261,6 +266,43 @@ public class CloudPubSubSinkTaskTest {
     task.flush(partitionOffsets);
     verify(publisher, times(1)).publish(any(PublishRequest.class));
     verify(badFuture, times(1)).get();
+  }
+
+  /**
+   * Tests if configured value converter runs and serializes Kafka Connect Record properly
+   */
+  @Test
+  public void testValueConverter(){
+    props.put(CloudPubSubSinkConnector.VALUE_CONVERTER, SillyStringConverter.class.getName());
+    String prefix = "123_";
+    props.put(CloudPubSubSinkConnector.VALUE_CONVERTER + ".prefix", prefix);
+    task.start(props);
+    SinkRecord sinkRecord = new SinkRecord(KAFKA_TOPIC, 0 , STRING_SCHEMA, "key", Schema.STRING_SCHEMA, "test", 0);
+    task.put(Arrays.asList(sinkRecord));
+    task.flush(new HashMap<TopicPartition, OffsetAndMetadata>());
+    ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(publisher, times(1)).publish(captor.capture());
+    PublishRequest publishRequest = captor.getValue();
+    PubsubMessage message = publishRequest.getMessages(0);
+    assertEquals(prefix + sinkRecord.value().toString(), new String(message.getData().toByteArray()));
+  }
+
+  public static class SillyStringConverter implements Converter {
+    private String prefix;
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+      prefix = configs.get("prefix").toString();
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+      return new String(prefix + value.toString()).getBytes();
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+      return null;
+    }
   }
 
   /** Get some sample SinkRecords's to use in the tests. */

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;


### PR DESCRIPTION
Current implementation of `CloudPubSubSinkConnector` has limited support for serialization.The idea is to enable different serialization formats (eg. Json, Avro) and to decouple serialization from Sink connector. There are already available converters for different formats that can be easily plugged in and avoid implementing serialization logic within sink connector. 

