### PR TITLE
Preserve timestamp information from pub/sub message

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import com.google.protobuf.util.Timestamps;
 import com.google.pubsub.kafka.common.ConnectorUtils;
 import com.google.pubsub.kafka.source.CloudPubSubSourceConnector.PartitionScheme;
 import com.google.pubsub.v1.AcknowledgeRequest;
@@ -170,7 +171,8 @@ public class CloudPubSubSourceTask extends SourceTask {
                 Schema.OPTIONAL_STRING_SCHEMA,
                 key,
                 valueSchema,
-                value);
+                value,
+                Timestamps.toMillis(message.getPublishTime()));
         } else {
           record =
             new SourceRecord(
@@ -181,7 +183,8 @@ public class CloudPubSubSourceTask extends SourceTask {
                 Schema.OPTIONAL_STRING_SCHEMA,
                 key,
                 Schema.BYTES_SCHEMA,
-                messageBytes);
+                messageBytes,
+                Timestamps.toMillis(message.getPublishTime()));
         }
         sourceRecords.add(record);
       }


### PR DESCRIPTION
Think that would be nice to have pub/sub timestmap information in Kafka. That way you can more easily relate messages between those two systems. 