### PR TITLE
Ack was accidentally gone

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -107,6 +107,7 @@ public class CloudPubSubSourceTask extends SourceTask {
 
   @Override
   public List<SourceRecord> poll() throws InterruptedException {
+    ackMessages();
     log.debug("Polling...");
     PullRequest request =
         PullRequest.newBuilder()

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -139,10 +139,8 @@ public class CloudPubSubSourceTaskTest {
     when(subscriber.ackMessages(any(AcknowledgeRequest.class))).thenReturn(goodFuture);
     when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
     result = task.poll();
-    task.commit();
     assertEquals(0, result.size());
     result = task.poll();
-    task.commit();
     assertEquals(0, result.size());
     verify(subscriber, times(1)).ackMessages(any(AcknowledgeRequest.class));
   }


### PR DESCRIPTION
Ack was accidentally removed from poll method which prevented pub/sub messages to be acknowledged ( they would only get eventually acknowledged in connector shutdown ).  