### PR TITLE
Adding timestamp message attribute 

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -171,7 +171,8 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             Type.STRING,
             null,
             Importance.MEDIUM,
-            "The optional Cloud Pub/Sub message attribute to use as a timestamp for messages published to Kafka.")
+            "The optional Cloud Pub/Sub message attribute to use as a timestamp for messages published to Kafka."
+                + "The timestamp is Long value.")
         .define(
             KAFKA_PARTITIONS_CONFIG,
             Type.INT,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -46,6 +46,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public static final String KAFKA_PARTITIONS_CONFIG = "kafka.partition.count";
   public static final String KAFKA_PARTITION_SCHEME_CONFIG = "kafka.partition.scheme";
   public static final String KAFKA_MESSAGE_KEY_CONFIG = "kafka.key.attribute";
+  public static final String KAFKA_MESSAGE_TIMESTAMP_CONFIG = "kafka.timestamp.attribute";
   public static final String KAFKA_TOPIC_CONFIG = "kafka.topic";
   public static final String CPS_SUBSCRIPTION_CONFIG = "cps.subscription";
   public static final String CPS_MAX_BATCH_SIZE_CONFIG = "cps.maxBatchSize";
@@ -165,6 +166,12 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             null,
             Importance.MEDIUM,
             "The Cloud Pub/Sub message attribute to use as a key for messages published to Kafka.")
+        .define(
+            KAFKA_MESSAGE_TIMESTAMP_CONFIG,
+            Type.STRING,
+            null,
+            Importance.MEDIUM,
+            "The optional Cloud Pub/Sub message attribute to use as a timestamp for messages published to Kafka.")
         .define(
             KAFKA_PARTITIONS_CONFIG,
             Type.INT,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -137,7 +137,7 @@ public class CloudPubSubSourceTask extends SourceTask {
         ackIds.add(ackId);
         Map<String, String> messageAttributes = message.getAttributes();
         String key = messageAttributes.get(kafkaMessageKeyAttribute);
-        Long timestamp = timestampAttribute(messageAttributes.get(kafkaMessageTimestampAttribute));
+        Long timestamp = getLongValue(messageAttributes.get(kafkaMessageTimestampAttribute));
         if(timestamp == null){
           timestamp = Timestamps.toMillis(message.getPublishTime());
         }
@@ -255,8 +255,7 @@ public class CloudPubSubSourceTask extends SourceTask {
     }
   }
 
-  private Long timestampAttribute(String timestamp){
-    if(timestamp == null) return null;
+  private Long getLongValue(String timestamp){
     try {
       return Long.valueOf(timestamp);
     } catch (NumberFormatException e){

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -255,10 +255,13 @@ public class CloudPubSubSourceTask extends SourceTask {
     }
   }
 
-  private Long getLongValue(String timestamp){
+  private Long getLongValue(String timestamp) {
+    if(timestamp == null) {
+      return null;
+    }
     try {
       return Long.valueOf(timestamp);
-    } catch (NumberFormatException e){
+    } catch (NumberFormatException e) {
       log.error("Error while converting `{}` to number", timestamp, e);
     }
     return null;


### PR DESCRIPTION
When moving messages from Pubsub to Kafka, Kafka message ingress time is set to Pubsub message publish time. In some cases would be more appropriate to set Kafka ingress time to some other time (eg. event time contained in the payload). This way the semantics and reasoning about time is the same across different systems ( Kafka supports traversing through message offset by time so being able to control ingress time is important for many scenarios like backup/restore )