### PR TITLE
Implementation of flic load-test-framework to support pub/sub kafka emulator repo.

### DIFF
--- a/load-test-framework/README.md
+++ b/load-test-framework/README.md
@@ -14,10 +14,29 @@ The goal of this framework is twofold:
 
 ### Quickstart
 
-You must have [Maven](https://maven.apache.org/) installed, be running on an Unix environment, either Linux or Mac OS X, and have the `zip` command line utility available.  
+1. Install [Maven](https://maven.apache.org/), must be running on an Unix environment, either Linux or Mac OS X.
+
+2. Install `zip` command line utility.
+
+3. Install `unzip` command line utility.
+
+4. Install `gnuplot` command line utility.
+
+5. Install and configure [GO Lang](https://golang.org/).
+
+6. Install load test dependency `go get -u cloud.google.com/go/pubsub/loadtest/cmd`.
+  
 You can then run `python run.py --project=<your_project>` which will install the load test framework and run a basic load test.  
 The `--test` parameter changes the test type. The default is 'latency', but it can also be set to 'throughput' which will test the maximum throughput on a single VM at different numbers of cores, and 'service' which will test maximum throughput on a 16 core VM.  
-The `--client_types` parameter to sets the clients to test. This is a comma deliminated list, valid options being 'gcloud_python', 'gcloud_java', and 'vtk'. 'experimental' requires you to be whitelisted for access to an experimental feature of Cloud Pub/Sub. You can contact cloud-pubsub@google.com to request access.
+The `--client_types` parameter to sets the clients to test. This is a comma delimited list, valid options being 'gcloud_python', 'gcloud_java', 'vtk'. 'experimental' requires you to be whitelisted for access to an experimental feature of Cloud Pub/Sub. You can contact cloud-pubsub@google.com to request access.
+
+For `gcloud_java` you have the option to execute on pub/sub emulator but you must provide:
+
+1. `--emulator_host` parameter to specify the host of Pub/Sub `<host>:<port>`.
+
+2. (Optional) `--topic` parameter to specify topic name.
+
+3. (Optional) `--subscription` parameter to specify subscription name.
 
 ### Pre-Running Steps
 

--- a/load-test-framework/flic.iml
+++ b/load-test-framework/flic.iml
@@ -1,31 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/java" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/grpc-java" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/python_src/clients" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/target/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/target/maven-archiver" />
-      <excludeFolder url="file://$MODULE_DIR$/target/protoc-dependencies" />
-      <excludeFolder url="file://$MODULE_DIR$/target/protoc-plugins" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire-reports" />
-      <excludeFolder url="file://$MODULE_DIR$/target/test-classes" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/grpc-java" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/protobuf/java" isTestSource="false" generated="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.kafka:kafka_2.10:0.10.0.0" level="project" />
-    <orderEntry type="library" name="Maven: com.101tec:zkclient:0.8" level="project" />
-    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.10.6" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.kafka:kafka_2.11:0.10.0.0" level="project" />
     <orderEntry type="library" name="Maven: com.yammer.metrics:metrics-core:2.2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.11.8" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.kafka:kafka-clients:0.10.0.0" level="project" />
     <orderEntry type="library" name="Maven: net.jpountz.lz4:lz4:1.3.0" level="project" />
     <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.1.2.4" level="project" />
@@ -34,37 +27,45 @@
     <orderEntry type="library" name="Maven: jline:jline:0.9.94" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty:3.7.0.Final" level="project" />
     <orderEntry type="library" name="Maven: com.beust:jcommander:1.48" level="project" />
+    <orderEntry type="library" name="Maven: com.google.cloud:google-cloud-pubsub:0.33.0-beta" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-tcnative-boringssl-static:2.0.7.Final" level="project" />
+    <orderEntry type="library" name="Maven: com.google.cloud:google-cloud-core:1.15.0" level="project" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:2.9.2" level="project" />
+    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java-util:3.5.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.7" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api.grpc:proto-google-iam-v1:0.1.28" level="project" />
+    <orderEntry type="library" name="Maven: com.google.cloud:google-cloud-core-grpc:1.15.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:3.5.1" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-context:1.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.28" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-netty:1.9.0" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-core:1.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.instrumentation:instrumentation-api:0.4.3" level="project" />
+    <orderEntry type="library" name="Maven: io.opencensus:opencensus-api:0.10.0" level="project" />
+    <orderEntry type="library" name="Maven: io.opencensus:opencensus-contrib-grpc-metrics:0.10.0" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-handler-proxy:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.netty:netty-codec-socks:4.1.17.Final" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-stub:1.9.0" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-auth:1.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.28" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-protobuf:1.7.0" level="project" />
+    <orderEntry type="library" name="Maven: io.grpc:grpc-protobuf-lite:1.7.0" level="project" />
     <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.4" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-all:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-auth:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.auth:google-auth-library-credentials:0.4.0" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-context:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-protobuf-nano:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.protobuf.nano:protobuf-javanano:3.0.0-alpha-5" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-core:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.0" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-okhttp:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.squareup.okio:okio:1.6.0" level="project" />
-    <orderEntry type="library" name="Maven: com.squareup.okhttp:okhttp:2.5.0" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-protobuf-lite:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-lite:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-netty:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http2:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-codec:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-handler:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-buffer:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-common:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-transport:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-resolver:4.1.3.Final" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-protobuf:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java:3.0.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.protobuf:protobuf-java-util:3.0.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.3" level="project" />
-    <orderEntry type="library" name="Maven: io.grpc:grpc-stub:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-tcnative-boringssl-static:linux-x86_64:1.1.33.Fork14" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:22.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
+    <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.0.18" level="project" />
+    <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.codehaus.mojo:animal-sniffer-annotations:1.14" level="project" />
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-pubsub:v1-rev7-1.21.0" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.21" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-log4j12:1.7.21" level="project" />
@@ -73,45 +74,27 @@
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-storage:v1-rev85-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-monitoring:v3-rev9-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.api-client:google-api-client:1.22.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client:1.20.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client:1.20.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-jackson2:1.20.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client:1.22.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-jackson2:1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.1.3" level="project" />
-    <orderEntry type="library" name="Maven: com.google.guava:guava-jdk5:13.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava-jdk5:17.0" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.2.5" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.2.5" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.1" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.6" level="project" />
-    <orderEntry type="library" name="Maven: com.google.cloud:google-cloud-pubsub:0.4.0" level="project" />
-    <orderEntry type="library" name="Maven: io.netty:netty-tcnative-boringssl-static:1.1.33.Fork19" level="project" />
-    <orderEntry type="library" name="Maven: com.google.cloud:google-cloud-core:0.4.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.auth:google-auth-library-oauth2-http:0.3.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api-client:google-api-client-appengine:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-appengine:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-servlet:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-jdo:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api-client:google-api-client-servlet:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: javax.jdo:jdo2-api:2.3-eb" level="project" />
-    <orderEntry type="library" name="Maven: javax.transaction:transaction-api:1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-appengine:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.http-client:google-http-client-jackson:1.21.0" level="project" />
-    <orderEntry type="library" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.11" level="project" />
-    <orderEntry type="library" name="Maven: joda-time:joda-time:2.9.2" level="project" />
-    <orderEntry type="library" name="Maven: org.json:json:20151123" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api:gax:0.0.18" level="project" />
-    <orderEntry type="library" name="Maven: com.google.auto.value:auto-value:1.1" level="project" />
-    <orderEntry type="library" name="Maven: com.google.inject:guice:4.0" level="project" />
-    <orderEntry type="library" name="Maven: javax.inject:javax.inject:1" level="project" />
-    <orderEntry type="library" name="Maven: aopalliance:aopalliance:1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-common-protos:0.1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-iam-v1:0.1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.google.api.grpc:grpc-google-pubsub-v1:0.1.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.apis:google-api-services-sheets:v4-rev108-1.22.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-java6:1.11.0-beta" level="project" />
     <orderEntry type="library" name="Maven: com.google.oauth-client:google-oauth-client-jetty:1.22.0" level="project" />
     <orderEntry type="library" name="Maven: org.mortbay.jetty:jetty:6.1.26" level="project" />
     <orderEntry type="library" name="Maven: org.mortbay.jetty:jetty-util:6.1.26" level="project" />
     <orderEntry type="library" name="Maven: org.mortbay.jetty:servlet-api:2.5-20081211" level="project" />
+    <orderEntry type="library" name="Maven: com.101tec:zkclient:0.7" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api:gax:1.24.0" level="project" />
+    <orderEntry type="library" name="Maven: org.threeten:threetenbp:1.3.3" level="project" />
+    <orderEntry type="library" name="Maven: com.google.auth:google-auth-library-oauth2-http:0.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api:api-common:1.5.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api:gax-grpc:1.24.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.auth:google-auth-library-credentials:0.9.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.api.grpc:proto-google-common-protos:1.0.0" level="project" />
   </component>
 </module>

--- a/load-test-framework/pom.xml
+++ b/load-test-framework/pom.xml
@@ -26,7 +26,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>0.24.0-beta</version>
+      <version>0.33.0-beta</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-pubsub-v1</artifactId>
+      <version>0.1.28</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -119,6 +124,16 @@
        <artifactId>zkclient</artifactId>
        <version>0.7</version>
      </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+      <version>RELEASE</version>
+    </dependency>
   </dependencies>
   <build>
    <resources>

--- a/load-test-framework/run.py
+++ b/load-test-framework/run.py
@@ -52,33 +52,33 @@ def main(project, test, client_types, vms_count, broker):
       sys.exit('cannot build Go load tester, maybe run `go get -u {}`?'.format(go_package))
 
     subprocess.call([
-        'zip', './target/classes/gce/cps.zip',
-        './python_src/clients/cps_publisher_task.py',
-        './python_src/clients/cps_subscriber_task.py',
-        './python_src/clients/loadtest_pb2.py',
-        './python_src/clients/requirements.txt',
-        './ruby_src/Gemfile',
-        './ruby_src/loadtest_pb.rb',
-        './ruby_src/loadtest_services_pb.rb',
-        './ruby_src/cps_publisher_task.rb',
-        './ruby_src/cps_subscriber_task.rb' ,
-        './node_src/publisher_client.js' ,
-        './node_src/subscriber_client.js' ,
-        './node_src/package.json' ,
-        './node_src/loadtest.proto' ,
-        './node_src/google/protobuf/duration.proto' ,
-        './node_src/google/protobuf/timestamp.proto',
-        './dotnet_src/Publisher/CPSPublisherTask.cs',
-        './dotnet_src/Publisher/Loadtest.cs',
-        './dotnet_src/Publisher/LoadtestGrpc.cs',
-        './dotnet_src/Publisher/Worker.csproj',
-        './dotnet_src/Publisher.sln',
-        './dotnet_src/Subscriber/CPSSubscriberTask.cs',
-        './dotnet_src/Subscriber/Loadtest.cs',
-        './dotnet_src/Subscriber/LoadtestGrpc.cs',
-        './dotnet_src/Subscriber/Worker.csproj',
-        './dotnet_src/Subscriber.sln',
-        go_bin_location
+      'zip', './target/classes/gce/cps.zip',
+      './python_src/clients/cps_publisher_task.py',
+      './python_src/clients/cps_subscriber_task.py',
+      './python_src/clients/loadtest_pb2.py',
+      './python_src/clients/requirements.txt',
+      './ruby_src/Gemfile',
+      './ruby_src/loadtest_pb.rb',
+      './ruby_src/loadtest_services_pb.rb',
+      './ruby_src/cps_publisher_task.rb',
+      './ruby_src/cps_subscriber_task.rb' ,
+      './node_src/publisher_client.js' ,
+      './node_src/subscriber_client.js' ,
+      './node_src/package.json' ,
+      './node_src/loadtest.proto' ,
+      './node_src/google/protobuf/duration.proto' ,
+      './node_src/google/protobuf/timestamp.proto',
+      './dotnet_src/Publisher/CPSPublisherTask.cs',
+      './dotnet_src/Publisher/Loadtest.cs',
+      './dotnet_src/Publisher/LoadtestGrpc.cs',
+      './dotnet_src/Publisher/Worker.csproj',
+      './dotnet_src/Publisher.sln',
+      './dotnet_src/Subscriber/CPSSubscriberTask.cs',
+      './dotnet_src/Subscriber/Loadtest.cs',
+      './dotnet_src/Subscriber/LoadtestGrpc.cs',
+      './dotnet_src/Subscriber/Worker.csproj',
+      './dotnet_src/Subscriber.sln',
+      go_bin_location
     ])
   arg_list = ['java', '-jar', 'target/driver.jar', '--project', project]
   gcloud_subscriber_count = 0
@@ -103,28 +103,28 @@ def main(project, test, client_types, vms_count, broker):
       arg_list.append('--cps_gcloud_dotnet_subscriber_count=' + str(vms_count))
   if broker:
     arg_list.extend([
-        '--broker=' + broker, '--kafka_publisher_count=' + str(vms_count),
-        '--kafka_subscriber_count=' + str(vms_count)
+      '--broker=' + broker, '--kafka_publisher_count=' + str(vms_count),
+      '--kafka_subscriber_count=' + str(vms_count)
     ])
   if test == 'latency':
     arg_list.extend([
-        '--message_size=1', '--publish_batch_size=1', '--request_rate=1',
-        '--max_outstanding_requests=10', '--loadtest_duration=10m',
-        '--burn_in_duration=2m', '--publish_batch_duration=1ms'
+      '--message_size=1', '--publish_batch_size=1', '--request_rate=1',
+      '--max_outstanding_requests=10', '--loadtest_duration=10m',
+      '--burn_in_duration=2m', '--publish_batch_duration=1ms'
     ])
   elif test == 'throughput':
     arg_list.extend([
-        '--message_size=10000', '--publish_batch_size=10',
-        '--request_rate=1000000000', '--max_outstanding_requests=1600',
-        '--loadtest_duration=10m', '--burn_in_duration=2m',
-        '--publish_batch_duration=50ms', '--num_cores_test'
+      '--message_size=10000', '--publish_batch_size=10',
+      '--request_rate=1000000000', '--max_outstanding_requests=1600',
+      '--loadtest_duration=10m', '--burn_in_duration=2m',
+      '--publish_batch_duration=50ms', '--num_cores_test'
     ])
   elif test == 'service':
     arg_list.extend([
-        '--message_size=10000', '--publish_batch_size=10',
-        '--request_rate=1000000000', '--max_outstanding_requests=1600',
-        '--loadtest_duration=10m', '--burn_in_duration=2m',
-        '--publish_batch_duration=50ms', '--cores=16'
+      '--message_size=10000', '--publish_batch_size=10',
+      '--request_rate=1000000000', '--max_outstanding_requests=1600',
+      '--loadtest_duration=10m', '--burn_in_duration=2m',
+      '--publish_batch_duration=50ms', '--cores=16'
     ])
   print(' '.join(arg_list))
   subprocess.call(arg_list)

--- a/load-test-framework/src/main/java/com/google/api/gax/grpc/LoadTestGrpcChannelProvider.java
+++ b/load-test-framework/src/main/java/com/google/api/gax/grpc/LoadTestGrpcChannelProvider.java
@@ -1,0 +1,418 @@
+package com.google.api.gax.grpc;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.threeten.bp.Duration;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalExtensionOnly;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.FixedExecutorProvider;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.TransportChannel;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import javax.annotation.Nullable;
+
+/**
+ * LoadTestGrpcChannelProvider is a TransportChannelProvider which constructs a gRPC ManagedChannel
+ * with a number of configured inputs every time getChannel(...) is called. These inputs include a
+ * port, a service address, and credentials.
+ *
+ * <p>The credentials can either be supplied directly (by providing a FixedCredentialsProvider to
+ * Builder.setCredentialsProvider()) or acquired implicitly from Application Default Credentials (by
+ * providing a GoogleCredentialsProvider to Builder.setCredentialsProvider()).
+ *
+ * <p>The client lib header and generator header values are used to form a value that goes into the
+ * http header of requests to the service.
+ *
+ * Using insecure connection.
+ */
+@InternalExtensionOnly
+public final class LoadTestGrpcChannelProvider implements TransportChannelProvider {
+
+  private final int processorCount;
+  private final ExecutorProvider executorProvider;
+  private final HeaderProvider headerProvider;
+  private final String endpoint;
+  @Nullable
+  private final Integer maxInboundMessageSize;
+  @Nullable
+  private final Duration keepAliveTime;
+  @Nullable
+  private final Duration keepAliveTimeout;
+  @Nullable
+  private final Boolean keepAliveWithoutCalls;
+  @Nullable
+  private final Integer poolSize;
+
+  private LoadTestGrpcChannelProvider(Builder builder) {
+    this.processorCount = builder.processorCount;
+    this.executorProvider = builder.executorProvider;
+    this.headerProvider = builder.headerProvider;
+    this.endpoint = builder.endpoint;
+    this.maxInboundMessageSize = builder.maxInboundMessageSize;
+    this.keepAliveTime = builder.keepAliveTime;
+    this.keepAliveTimeout = builder.keepAliveTimeout;
+    this.keepAliveWithoutCalls = builder.keepAliveWithoutCalls;
+    this.poolSize = builder.poolSize;
+  }
+
+  @Override
+  public boolean needsExecutor() {
+    return executorProvider == null;
+  }
+
+  @Override
+  public TransportChannelProvider withExecutor(ScheduledExecutorService executor) {
+    return toBuilder().setExecutorProvider(FixedExecutorProvider.create(executor)).build();
+  }
+
+  @Override
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public boolean needsHeaders() {
+    return headerProvider == null;
+  }
+
+  @Override
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public TransportChannelProvider withHeaders(Map<String, String> headers) {
+    return toBuilder().setHeaderProvider(FixedHeaderProvider.create(headers)).build();
+  }
+
+  @Override
+  public String getTransportName() {
+    return GrpcTransportChannel.getGrpcTransportName();
+  }
+
+  @Override
+  public boolean needsEndpoint() {
+    return endpoint == null;
+  }
+
+  @Override
+  public TransportChannelProvider withEndpoint(String endpoint) {
+    validateEndpoint(endpoint);
+    return toBuilder().setEndpoint(endpoint).build();
+  }
+
+  @Override
+  @BetaApi("The surface for customizing pool size is not stable yet and may change in the future.")
+  public boolean acceptsPoolSize() {
+    return poolSize == null;
+  }
+
+  @Override
+  @BetaApi("The surface for customizing pool size is not stable yet and may change in the future.")
+  public TransportChannelProvider withPoolSize(int size) {
+    Preconditions.checkState(acceptsPoolSize(), "pool size already set to %s", poolSize);
+    return toBuilder().setPoolSize(size).build();
+  }
+
+  @Override
+  public TransportChannel getTransportChannel() throws IOException {
+    if (needsExecutor()) {
+      throw new IllegalStateException("getTransportChannel() called when needsExecutor() is true");
+    } else if (needsHeaders()) {
+      throw new IllegalStateException("getTransportChannel() called when needsHeaders() is true");
+    } else if (needsEndpoint()) {
+      throw new IllegalStateException("getTransportChannel() called when needsEndpoint() is true");
+    } else {
+      return createChannel();
+    }
+  }
+
+  private TransportChannel createChannel() throws IOException {
+    ManagedChannel outerChannel;
+
+    if (poolSize == null || poolSize == 1) {
+      outerChannel = createSingleChannel();
+    } else {
+      ImmutableList.Builder<ManagedChannel> channels = ImmutableList.builder();
+
+      for (int i = 0; i < poolSize; i++) {
+        channels.add(createSingleChannel());
+      }
+      outerChannel = new ChannelPool(channels.build());
+    }
+
+    return GrpcTransportChannel.create(outerChannel);
+  }
+
+  private ManagedChannel createSingleChannel() throws IOException {
+    ScheduledExecutorService executor = executorProvider.getExecutor();
+    GrpcHeaderInterceptor headerInterceptor =
+        new GrpcHeaderInterceptor(headerProvider.getHeaders());
+    GrpcMetadataHandlerInterceptor metadataHandlerInterceptor =
+        new GrpcMetadataHandlerInterceptor();
+
+    int colon = endpoint.indexOf(':');
+    if (colon < 0) {
+      throw new IllegalStateException("invalid endpoint - should have been validated: " + endpoint);
+    }
+    int port = Integer.parseInt(endpoint.substring(colon + 1));
+    String serviceAddress = endpoint.substring(0, colon);
+
+    ManagedChannelBuilder builder =
+        ManagedChannelBuilder.forAddress(serviceAddress, port)
+            .intercept(headerInterceptor)
+            .intercept(metadataHandlerInterceptor)
+            .userAgent(headerInterceptor.getUserAgentHeader())
+            .usePlaintext(true)
+            .executor(executor);
+    if (maxInboundMessageSize != null) {
+      builder.maxInboundMessageSize(maxInboundMessageSize);
+    }
+    if (keepAliveTime != null) {
+      builder.keepAliveTime(keepAliveTime.toMillis(), TimeUnit.MILLISECONDS);
+    }
+    if (keepAliveTimeout != null) {
+      builder.keepAliveTimeout(keepAliveTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+    if (keepAliveWithoutCalls != null) {
+      builder.keepAliveWithoutCalls(keepAliveWithoutCalls);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * The endpoint to be used for the channel.
+   */
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  /**
+   * The time without read activity before sending a keepalive ping.
+   */
+  public Duration getKeepAliveTime() {
+    return keepAliveTime;
+  }
+
+  /**
+   * The time without read activity after sending a keepalive ping.
+   */
+  public Duration getKeepAliveTimeout() {
+    return keepAliveTimeout;
+  }
+
+  /**
+   * Whether keepalive will be performed when there are no outstanding RPCs.
+   */
+  public Boolean getKeepAliveWithoutCalls() {
+    return keepAliveWithoutCalls;
+  }
+
+  @Override
+  public boolean shouldAutoClose() {
+    return true;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private int processorCount;
+    private ExecutorProvider executorProvider;
+    private HeaderProvider headerProvider;
+    private String endpoint;
+    @Nullable
+    private Integer maxInboundMessageSize;
+    @Nullable
+    private Duration keepAliveTime;
+    @Nullable
+    private Duration keepAliveTimeout;
+    @Nullable
+    private Boolean keepAliveWithoutCalls;
+    @Nullable
+    private Integer poolSize;
+
+    private Builder() {
+      processorCount = Runtime.getRuntime().availableProcessors();
+    }
+
+    private Builder(LoadTestGrpcChannelProvider provider) {
+      this.processorCount = provider.processorCount;
+      this.executorProvider = provider.executorProvider;
+      this.headerProvider = provider.headerProvider;
+      this.endpoint = provider.endpoint;
+      this.maxInboundMessageSize = provider.maxInboundMessageSize;
+      this.keepAliveTime = provider.keepAliveTime;
+      this.keepAliveTimeout = provider.keepAliveTimeout;
+      this.keepAliveWithoutCalls = provider.keepAliveWithoutCalls;
+      this.poolSize = provider.poolSize;
+    }
+
+    /**
+     * Sets the number of available CPUs, used internally for testing.
+     */
+    Builder setProcessorCount(int processorCount) {
+      this.processorCount = processorCount;
+      return this;
+    }
+
+    /**
+     * Sets the ExecutorProvider for this TransportChannelProvider.
+     *
+     * <p>This is optional; if it is not provided, needsExecutor() will return true, meaning that
+     * an Executor must be provided when getChannel is called on the constructed
+     * TransportChannelProvider instance. Note: GrpcTransportProvider will automatically provide its
+     * own Executor in this circumstance when it calls getChannel.
+     */
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      this.executorProvider = executorProvider;
+      return this;
+    }
+
+    /**
+     * Sets the HeaderProvider for this TransportChannelProvider.
+     *
+     * <p>This is optional; if it is not provided, needsHeaders() will return true, meaning that
+     * headers must be provided when getChannel is called on the constructed
+     * TransportChannelProvider instance.
+     */
+    public Builder setHeaderProvider(HeaderProvider headerProvider) {
+      this.headerProvider = headerProvider;
+      return this;
+    }
+
+    /**
+     * Sets the endpoint used to reach the service, eg "localhost:8080".
+     */
+    public Builder setEndpoint(String endpoint) {
+      validateEndpoint(endpoint);
+      this.endpoint = endpoint;
+      return this;
+    }
+
+    public String getEndpoint() {
+      return endpoint;
+    }
+
+    /**
+     * The maximum message size allowed to be received on the channel.
+     */
+    public Builder setMaxInboundMessageSize(Integer max) {
+      this.maxInboundMessageSize = max;
+      return this;
+    }
+
+    /**
+     * The maximum message size allowed to be received on the channel.
+     */
+    public Integer getMaxInboundMessageSize() {
+      return maxInboundMessageSize;
+    }
+
+    /**
+     * The time without read activity before sending a keepalive ping.
+     */
+    public Builder setKeepAliveTime(Duration duration) {
+      this.keepAliveTime = duration;
+      return this;
+    }
+
+    /**
+     * The time without read activity before sending a keepalive ping.
+     */
+    public Duration getKeepAliveTime() {
+      return keepAliveTime;
+    }
+
+    /**
+     * The time without read activity after sending a keepalive ping.
+     */
+    public Builder setKeepAliveTimeout(Duration duration) {
+      this.keepAliveTimeout = duration;
+      return this;
+    }
+
+    /**
+     * The time without read activity after sending a keepalive ping.
+     */
+    public Duration getKeepAliveTimeout() {
+      return keepAliveTimeout;
+    }
+
+    /**
+     * Whether keepalive will be performed when there are no outstanding RPCs.
+     */
+    public Builder setKeepAliveWithoutCalls(Boolean keepalive) {
+      this.keepAliveWithoutCalls = keepalive;
+      return this;
+    }
+
+    /**
+     * Whether keepalive will be performed when there are no outstanding RPCs.
+     */
+    public Boolean getKeepAliveWithoutCalls() {
+      return keepAliveWithoutCalls;
+    }
+
+    /**
+     * Number of underlying grpc channels to open. Calls will be load balanced round robin across
+     * them.
+     */
+    public int getPoolSize() {
+      if (poolSize == null) {
+        return 1;
+      }
+      return poolSize;
+    }
+
+    /**
+     * Number of underlying grpc channels to open. Calls will be load balanced round robin across
+     * them
+     */
+    public Builder setPoolSize(int poolSize) {
+      Preconditions.checkArgument(poolSize > 0, "Pool size must be positive");
+      this.poolSize = poolSize;
+      return this;
+    }
+
+    /**
+     * Sets the number of channels relative to the available CPUs.
+     */
+    public Builder setChannelsPerCpu(double multiplier) {
+      return setChannelsPerCpu(multiplier, 100);
+    }
+
+    public Builder setChannelsPerCpu(double multiplier, int maxChannels) {
+      Preconditions.checkArgument(multiplier > 0, "multiplier must be positive");
+      Preconditions.checkArgument(maxChannels > 0, "maxChannels must be positive");
+
+      int channelCount = (int) Math.ceil(processorCount * multiplier);
+      if (channelCount > maxChannels) {
+        channelCount = maxChannels;
+      }
+      return setPoolSize(channelCount);
+    }
+
+    public LoadTestGrpcChannelProvider build() {
+      return new LoadTestGrpcChannelProvider(this);
+    }
+  }
+
+  private static void validateEndpoint(String endpoint) {
+    int colon = endpoint.indexOf(':');
+    if (colon < 0) {
+      throw new IllegalArgumentException(
+          String.format("invalid endpoint, expecting \"<host>:<port>\""));
+    }
+    Integer.parseInt(endpoint.substring(colon + 1));
+  }
+}

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/common/LoadTestSubscriptionAdminSettings.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/common/LoadTestSubscriptionAdminSettings.java
@@ -1,0 +1,17 @@
+package com.google.pubsub.clients.common;
+
+import com.google.api.gax.grpc.LoadTestGrpcChannelProvider;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import java.io.IOException;
+
+public class LoadTestSubscriptionAdminSettings extends SubscriptionAdminSettings {
+
+  protected LoadTestSubscriptionAdminSettings(
+      Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  public static LoadTestGrpcChannelProvider.Builder defaultGrpcTransportBuilder() {
+    return LoadTestGrpcChannelProvider.newBuilder();
+  }
+}

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/common/LoadTestTopicAdminSettings.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/common/LoadTestTopicAdminSettings.java
@@ -1,0 +1,16 @@
+package com.google.pubsub.clients.common;
+
+import com.google.api.gax.grpc.LoadTestGrpcChannelProvider;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import java.io.IOException;
+
+public class LoadTestTopicAdminSettings extends TopicAdminSettings {
+
+  protected LoadTestTopicAdminSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  public static LoadTestGrpcChannelProvider.Builder defaultGrpcTransportProvider() {
+    return LoadTestGrpcChannelProvider.newBuilder();
+  }
+}

--- a/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/clients/gcloud/CPSSubscriberTask.java
@@ -16,37 +16,44 @@
 package com.google.pubsub.clients.gcloud;
 
 import com.beust.jcommander.JCommander;
+import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.Subscriber.Builder;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.pubsub.clients.common.LoadTestRunner;
+import com.google.pubsub.clients.common.LoadTestSubscriptionAdminSettings;
 import com.google.pubsub.clients.common.MetricsHandler;
 import com.google.pubsub.clients.common.Task;
-import com.google.pubsub.clients.common.Task.RunResult;
 import com.google.pubsub.flic.common.LoadtestProto.StartRequest;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.SubscriptionName;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.threeten.bp.Duration;
 
 /** Runs a task that consumes messages from a Cloud Pub/Sub subscription. */
 class CPSSubscriberTask extends Task implements MessageReceiver {
+
   private static final Logger log = LoggerFactory.getLogger(CPSSubscriberTask.class);
   private final SubscriptionName subscription;
   private Subscriber subscriber;
   private boolean shuttingDown = false;
+  private final String emulatorHost;
+
+  private static final int MAX_INBOUND_MESSAGE_SIZE =
+      20 * 1024 * 1024; // 20MB API maximum message size.
 
   private CPSSubscriberTask(StartRequest request) {
     super(request, "gcloud", MetricsHandler.MetricName.END_TO_END_LATENCY);
-    this.subscription =
-        SubscriptionName.create(request.getProject(), request.getPubsubOptions().getSubscription());
+    this.subscription = SubscriptionName.of(request.getProject(),
+        request.getPubsubOptions().getSubscription());
+    this.emulatorHost = request.getEmulatorHost();
     try {
-      this.subscriber =
-          Subscriber.defaultBuilder(this.subscription, this)
-              .setParallelPullCount(Runtime.getRuntime().availableProcessors() * 5)
-              .build();
+      this.subscriber = getSubscriber();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -65,6 +72,23 @@ class CPSSubscriberTask extends Task implements MessageReceiver {
     LoadTestRunner.Options options = new LoadTestRunner.Options();
     new JCommander(options, args);
     LoadTestRunner.run(options, CPSSubscriberTask::new);
+  }
+
+  private Subscriber getSubscriber() {
+    Builder builder = Subscriber.newBuilder(subscription, this)
+        .setParallelPullCount(Runtime.getRuntime().availableProcessors() * 5);
+
+    if (Objects.nonNull(this.emulatorHost)) {
+      builder.setChannelProvider(
+          LoadTestSubscriptionAdminSettings.defaultGrpcTransportBuilder()
+              .setEndpoint(this.emulatorHost)
+              .setMaxInboundMessageSize(MAX_INBOUND_MESSAGE_SIZE)
+              .setKeepAliveTime(Duration.ofMinutes(5))
+              .build());
+      builder.setCredentialsProvider(new NoCredentialsProvider());
+    }
+
+    return builder.build();
   }
 
   @Override

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/Client.java
@@ -61,10 +61,11 @@ public class Client {
   public static int numberOfMessages = 0;
   public static int replicationFactor;
   public static int partitions;
+  public static String emulatorHost;
+  private final String topic;
   private final ClientType clientType;
   private final String networkAddress;
   private final String project;
-  private final String topic;
   private final String subscription;
   private final ScheduledExecutorService executorService;
   private ClientStatus clientStatus;
@@ -80,15 +81,17 @@ public class Client {
       ClientType clientType,
       String networkAddress,
       String project,
+      String topic,
       @Nullable String subscription,
       ScheduledExecutorService executorService) {
-    this(clientType, networkAddress, project, subscription, executorService, null);
+    this(clientType, networkAddress, project, topic, subscription, executorService, null);
   }
 
   public Client(
       ClientType clientType,
       String networkAddress,
       String project,
+      String topic,
       @Nullable String subscription,
       ScheduledExecutorService executorService,
       @Nullable Supplier<LoadtestGrpc.LoadtestStub> stubFactory) {
@@ -96,7 +99,7 @@ public class Client {
     this.networkAddress = networkAddress;
     this.clientStatus = ClientStatus.NONE;
     this.project = project;
-    this.topic = TOPIC_PREFIX + getTopicSuffix(clientType);
+    this.topic = topic;
     this.subscription = subscription;
     this.executorService = executorService;
     this.stubFactory = stubFactory;
@@ -170,6 +173,7 @@ public class Client {
             .setStartTime(startTime)
             .setPublishBatchSize(publishBatchSize)
             .setPublishBatchDuration(publishBatchDuration)
+            .setEmulatorHost(emulatorHost)
             .setBurnInDuration(burnInDuration);
     if (numberOfMessages > 0) {
       requestBuilder.setNumberOfMessages(numberOfMessages);

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/ClientParams.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/ClientParams.java
@@ -16,15 +16,29 @@
 
 package com.google.pubsub.flic.controllers;
 
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Keeps track of the parameters that define a client.
  */
 public class ClientParams {
+
+  public final String topic;
   public final String subscription;
   public final Client.ClientType clientType;
 
   public ClientParams(Client.ClientType clientType, String subscription) {
+    this(clientType, null, subscription);
+  }
+
+  public ClientParams(Client.ClientType clientType, String topic, String subscription) {
     this.clientType = clientType;
+    if (StringUtils.isBlank(topic)) {
+      this.topic = Client.TOPIC_PREFIX + Client.getTopicSuffix(clientType);
+    } else {
+      this.topic = topic;
+    }
     this.subscription = subscription;
   }
 
@@ -35,34 +49,26 @@ public class ClientParams {
     return clientType;
   }
 
+  public String getTopic() {
+    return topic;
+  }
+
   @Override
-  public boolean equals(Object obj) {
-    if (obj == this) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj == null || obj.getClass() != this.getClass()) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ClientParams other = (ClientParams) obj;
-    if (!clientType.equals(other.getClientType())) {
-      return false;
-    }
-    if (subscription == null && other.subscription == null) {
-      return true;
-    }
-    if (subscription == null || other.subscription == null) {
-      return false;
-    }
-    return subscription.equals(other.subscription);
+    ClientParams that = (ClientParams) o;
+    return Objects.equals(topic, that.topic) &&
+        Objects.equals(subscription, that.subscription) &&
+        clientType == that.clientType;
   }
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((subscription == null) ? 0 : subscription.hashCode());
-    result = prime * result + ((clientType == null) ? 0 : clientType.hashCode());
-    return result;
+    return Objects.hash(topic, subscription, clientType);
   }
-
 }

--- a/load-test-framework/src/main/java/com/google/pubsub/flic/output/GnuPlot.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/output/GnuPlot.java
@@ -16,10 +16,6 @@
 
 package com.google.pubsub.flic.output;
 
-import com.google.common.base.Ascii;
-import com.google.pubsub.flic.common.LatencyDistribution;
-import com.google.pubsub.flic.controllers.Client.ClientType;
-import com.google.pubsub.flic.controllers.Controller.LoadtestStats;
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -32,8 +28,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Ascii;
+import com.google.pubsub.flic.common.LatencyDistribution;
+import com.google.pubsub.flic.controllers.Client.ClientType;
+import com.google.pubsub.flic.controllers.Controller.LoadtestStats;
 
 /** Outputs results of the load test as a GnuPlot. */
 public class GnuPlot {
@@ -183,9 +185,13 @@ public class GnuPlot {
     DecimalFormat decimalFormat = new DecimalFormat("#.##");
     for (int cores = 1; cores <= 16; cores *= 2) {
       try {
+        Double coreValue = 0D;
+        if (throughputMap.containsKey(cores)) {
+          coreValue = throughputMap.get(cores);
+        }
         dat.append(cores)
             .append(" ")
-            .append(decimalFormat.format(throughputMap.get(cores)))
+            .append(decimalFormat.format(coreValue))
             .append("\n");
       } catch (Exception e) {
         log.error("There was a problem getting the results from one of the tests.", e);

--- a/load-test-framework/src/main/proto/loadtest.proto
+++ b/load-test-framework/src/main/proto/loadtest.proto
@@ -42,6 +42,9 @@ message StartRequest {
   // The maximum outstanding requests, per client.
   int32 max_outstanding_requests = 5;
 
+  // The Cloud Pub/Sub emulator host
+  string emulator_host = 14;
+
   // The time at which the load test should start. If this is less than the current time, we start immediately.
   google.protobuf.Timestamp start_time = 6;
 

--- a/load-test-framework/src/test/java/com/google/pubsub/flic/controllers/ClientTest.java
+++ b/load-test-framework/src/test/java/com/google/pubsub/flic/controllers/ClientTest.java
@@ -15,13 +15,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.google.pubsub.flic.controllers;
 
-import com.google.pubsub.flic.common.LatencyDistribution;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.google.pubsub.flic.common.LatencyDistribution;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Test;
 
 
@@ -34,7 +34,7 @@ public class ClientTest {
   @Test
   public void testEmpty() {
     Client client = new Client(Client.ClientType.CPS_GCLOUD_JAVA_PUBLISHER, "127.0.0.1",
-        "my-project", null, executor);
+        "my-project", null, null, executor);
     assertArrayEquals(client.getBucketValues(),
         new long[LatencyDistribution.LATENCY_BUCKETS.length]);
     assertEquals(client.getClientType(), Client.ClientType.CPS_GCLOUD_JAVA_PUBLISHER);


### PR DESCRIPTION
(https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator)

 - Change Publisher/Subscriber Tasks make possible execute on pubsub emulator
 - Create a LoadTestGrpcChannelProvider mirror of an InstantiatingGrpcChannelProvider to override gRPC connection settings using insecure connection(usePlainText true).
 - Update Client/Driver/GCEController methods to make possible execute over pub/sub emulator
 - Improve README.md.