### PR TITLE
add kafka_partitioner partition scheme

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -77,8 +77,8 @@ Connector supports the following configs:
 | kafka.topic | String | REQUIRED (No default) | The topic in Kafka which will receive messages that were pulled from Cloud Pub/Sub. |
 | cps.maxBatchSize | Integer | 100 | The minimum number of messages to batch per pull request to Cloud Pub/Sub. |
 | kafka.key.attribute | String | null | The Cloud Pub/Sub message attribute to use as a key for messages published to Kafka. |
-| kafka.partition.count | Integer | 1 | The number of Kafka partitions for the Kafka topic in which messages will be published to. |
-| kafka.partition.scheme | round_robin, hash_key, hash_value | round_robin | The scheme for assigning a message to a partition in Kafka. The scheme "round_robin" assigns partitions in a round robin fashion, while the schemes "hash_key" and "hash_value" find the partition by hashing the message key and message value respectively. |
+| kafka.partition.count | Integer | 1 | The number of Kafka partitions for the Kafka topic in which messages will be published to. NOTE: this parameter is ignored if partition scheme is "kafka_partitioner".|
+| kafka.partition.scheme | round_robin, hash_key, hash_value, kafka_partitioner | round_robin | The scheme for assigning a message to a partition in Kafka. The scheme "round_robin" assigns partitions in a round robin fashion, while the schemes "hash_key" and "hash_value" find the partition by hashing the message key and message value respectively. "kafka_partitioner" scheme delegates partitioning logic to kafka producer, which by default detects number of partitions automatically and performs either murmur hash based partition mapping or round robin depending on whether message key is provided or not.|
 
 #### Sink Connector
 

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -20,6 +20,7 @@ import com.google.pubsub.kafka.common.ConnectorUtils;
 import com.google.pubsub.v1.GetSubscriptionRequest;
 import com.google.pubsub.v1.SubscriberGrpc;
 import com.google.pubsub.v1.SubscriberGrpc.SubscriberFutureStub;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,7 +59,8 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public enum PartitionScheme {
     ROUND_ROBIN("round_robin"),
     HASH_KEY("hash_key"),
-    HASH_VALUE("hash_value");
+    HASH_VALUE("hash_value"),
+    KAFKA_PARTITIONER("kafka_partitioner");
 
     private String value;
 
@@ -77,6 +79,8 @@ public class CloudPubSubSourceConnector extends SourceConnector {
         return PartitionScheme.HASH_KEY;
       } else if (value.equals("hash_value")) {
         return PartitionScheme.HASH_VALUE;
+      } else if (value.equals("kafka_partitioner")) {
+        return PartitionScheme.KAFKA_PARTITIONER;
       } else {
         return null;
       }
@@ -90,11 +94,12 @@ public class CloudPubSubSourceConnector extends SourceConnector {
         String value = (String) o;
         if (!value.equals(CloudPubSubSourceConnector.PartitionScheme.ROUND_ROBIN.toString())
             && !value.equals(CloudPubSubSourceConnector.PartitionScheme.HASH_VALUE.toString())
-            && !value.equals(CloudPubSubSourceConnector.PartitionScheme.HASH_KEY.toString())) {
+            && !value.equals(CloudPubSubSourceConnector.PartitionScheme.HASH_KEY.toString())
+            && !value.equals(CloudPubSubSourceConnector.PartitionScheme.KAFKA_PARTITIONER.toString())) {
           throw new ConfigException(
               "Valid values for "
                   + CloudPubSubSourceConnector.KAFKA_PARTITION_SCHEME_CONFIG
-                  + " are hash_value, hash_key and round_robin");
+                  + " are " + Arrays.toString(PartitionScheme.values()));
         }
       }
     }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -244,11 +244,13 @@ public class CloudPubSubSourceTask extends SourceTask {
   }
 
   /** Return the partition a message should go to based on {@link #kafkaPartitionScheme}. */
-  private int selectPartition(Object key, Object value) {
+  private Integer selectPartition(Object key, Object value) {
     if (kafkaPartitionScheme.equals(PartitionScheme.HASH_KEY)) {
       return key == null ? 0 : Math.abs(key.hashCode()) % kafkaPartitions;
     } else if (kafkaPartitionScheme.equals(PartitionScheme.HASH_VALUE)) {
       return Math.abs(value.hashCode()) % kafkaPartitions;
+    } if (kafkaPartitionScheme.equals(PartitionScheme.KAFKA_PARTITIONER)) {
+      return null;
     } else {
       currentRoundRobinPartition = ++currentRoundRobinPartition % kafkaPartitions;
       return currentRoundRobinPartition;


### PR DESCRIPTION
New scheme relies on kafka producer to do the partitioning, which by default provides stable hashing based on message key or round robin if no key is specified. Number of partitions is automatically inferred by kafka producer.

Partially adresses https://github.com/GoogleCloudPlatform/pubsub/issues/171