### PR TITLE
kafka-connector: support explicit json credentials

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -89,7 +89,8 @@ Connector supports the following configs:
 | kafka.key.attribute | String | null | The Cloud Pub/Sub message attribute to use as a key for messages published to Kafka. |
 | kafka.partition.count | Integer | 1 | The number of Kafka partitions for the Kafka topic in which messages will be published to. NOTE: this parameter is ignored if partition scheme is "kafka_partitioner".|
 | kafka.partition.scheme | round_robin, hash_key, hash_value, kafka_partitioner | round_robin | The scheme for assigning a message to a partition in Kafka. The scheme "round_robin" assigns partitions in a round robin fashion, while the schemes "hash_key" and "hash_value" find the partition by hashing the message key and message value respectively. "kafka_partitioner" scheme delegates partitioning logic to kafka producer, which by default detects number of partitions automatically and performs either murmur hash based partition mapping or round robin depending on whether message key is provided or not.|
-|gcp.credentials.file.path| String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used.
+| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
+| gcp.credentials.json | String | Optional | GCP credentials JSON blob | If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
 
 #### Sink Connector
 
@@ -102,8 +103,8 @@ Connector supports the following configs:
 | maxDelayThresholdMs | Integer | 100 | The maximum amount of time to wait to reach maxBufferSize or maxBufferBytes before publishing outstanding messages to Cloud Pub/Sub. |
 | maxRequestTimeoutMs | Integer | 10000 | The timeout for individual publish requests to Cloud Pub/Sub. |
 | maxTotalTimeoutMs | Integer | 60000| The total timeout for a call to publish (including retries) to Cloud Pub/Sub. |
-|gcp.credentials.file.path| String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used.
-
+| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
+| gcp.credentials.json | String | Optional | GCP credentials JSON blob | If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
 
 #### Schema Support and Data Model
 

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
@@ -18,6 +18,7 @@ package com.google.pubsub.kafka.common;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -32,6 +33,11 @@ public class ConnectorCredentialsProvider implements CredentialsProvider {
 
   public void loadFromFile(String credentialPath) throws IOException {
     this.credentials = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
+  }
+
+  public void loadJson(String credentialsJson) throws IOException {
+    ByteArrayInputStream bs = new ByteArrayInputStream(credentialsJson.getBytes());
+    this.credentials = credentials = GoogleCredentials.fromStream(bs);
   }
 
   @Override

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
@@ -1,0 +1,46 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package com.google.pubsub.kafka.common;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class ConnectorCredentialsProvider implements CredentialsProvider {
+
+  private static final List<String> CPS_SCOPE =
+    Arrays.asList("https://www.googleapis.com/auth/pubsub");
+
+  GoogleCredentials credentials;
+
+  public void loadFromFile(String credentialPath) throws IOException {
+    this.credentials = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
+  }
+
+  @Override
+  public Credentials getCredentials() throws IOException {
+    if (this.credentials == null) {
+      return GoogleCredentials.getApplicationDefault().createScoped(this.CPS_SCOPE);
+    } else {
+      return this.credentials.createScoped(this.CPS_SCOPE);
+    }
+  }
+
+}

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.google.pubsub.kafka.common;
 
-import com.google.auth.oauth2.GoogleCredentials;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.protobuf.ByteString;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptors;
@@ -23,18 +23,13 @@ import io.grpc.ManagedChannel;
 import io.grpc.auth.ClientAuthInterceptor;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Executors;
 
 /** Utility methods and constants that are repeated across one or more classes. */
 public class ConnectorUtils {
 
   private static final String ENDPOINT = "pubsub.googleapis.com";
-  private static final List<String> CPS_SCOPE =
-      Arrays.asList("https://www.googleapis.com/auth/pubsub");
 
   public static final String SCHEMA_NAME = ByteString.class.getName();
   public static final String CPS_SUBSCRIPTION_FORMAT = "projects/%s/subscriptions/%s";
@@ -42,6 +37,7 @@ public class ConnectorUtils {
   public static final String CPS_PROJECT_CONFIG = "cps.project";
   public static final String CPS_TOPIC_CONFIG = "cps.topic";
   public static final String CPS_MESSAGE_KEY_ATTRIBUTE = "key";
+  public static final String GCP_CREDENTIALS_FILE_PATH_CONFIG  = "gcp.credentials.file.path";
   public static final String KAFKA_MESSAGE_CPS_BODY_FIELD = "message";
   public static final String KAFKA_TOPIC_ATTRIBUTE = "kafka.topic";
   public static final String KAFKA_PARTITION_ATTRIBUTE = "kafka.partition";
@@ -49,19 +45,18 @@ public class ConnectorUtils {
   public static final String KAFKA_TIMESTAMP_ATTRIBUTE = "kafka.timestamp";
 
   /** Return {@link io.grpc.Channel} which is used by Cloud Pub/Sub gRPC API's. */
-  public static Channel getChannel(String credKeyPath) throws IOException {
+  public static Channel getChannel(CredentialsProvider credentialsProvider) throws IOException {
     ManagedChannel channelImpl =
         NettyChannelBuilder.forAddress(ENDPOINT, 443)
             .negotiationType(NegotiationType.TLS)
             // Maximum Pub/Sub message size is 10MB.
             .maxInboundMessageSize(10 * 1024 * 1024)
             .build();
-    GoogleCredentials googleCredentials = credKeyPath == null ?
-        GoogleCredentials.getApplicationDefault() : GoogleCredentials.fromStream(new FileInputStream(credKeyPath));
     final ClientAuthInterceptor interceptor =
         new ClientAuthInterceptor(
-            googleCredentials.createScoped(CPS_SCOPE),
+            credentialsProvider.getCredentials(),
             Executors.newCachedThreadPool());
     return ClientInterceptors.intercept(channelImpl, interceptor);
   }
+
 }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -38,6 +38,7 @@ public class ConnectorUtils {
   public static final String CPS_TOPIC_CONFIG = "cps.topic";
   public static final String CPS_MESSAGE_KEY_ATTRIBUTE = "key";
   public static final String GCP_CREDENTIALS_FILE_PATH_CONFIG  = "gcp.credentials.file.path";
+  public static final String GCP_CREDENTIALS_JSON_CONFIG  = "gcp.credentials.json";
   public static final String KAFKA_MESSAGE_CPS_BODY_FIELD = "message";
   public static final String KAFKA_TOPIC_ATTRIBUTE = "kafka.topic";
   public static final String KAFKA_PARTITION_ATTRIBUTE = "kafka.partition";

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -50,7 +50,6 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final String CPS_MESSAGE_BODY_NAME = "messageBodyName";
   public static final String DEFAULT_MESSAGE_BODY_NAME = "cps_message_body";
   public static final String PUBLISH_KAFKA_METADATA = "metadata.publish";
-  public static final String GCP_CREDENTIALS_FILE_PATH  = "gcp.credentials.file.path";
   private Map<String, String> props;
 
   @Override
@@ -146,7 +145,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             "When using a struct or map value schema, this field or key name indicates that the "
                 + "corresponding value will go into the Pub/Sub message body.")
         .define(
-                GCP_CREDENTIALS_FILE_PATH,
+                ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG,
                 Type.STRING,
                 null,
                 Importance.HIGH,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -144,12 +144,16 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             Importance.MEDIUM,
             "When using a struct or map value schema, this field or key name indicates that the "
                 + "corresponding value will go into the Pub/Sub message body.")
-        .define(
-                ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG,
-                Type.STRING,
-                null,
-                Importance.HIGH,
-                "The path to the GCP credentials file");
+        .define(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG,
+            Type.STRING,
+            null,
+            Importance.HIGH,
+            "The path to the GCP credentials file")
+        .define(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG,
+            Type.STRING,
+            null,
+            Importance.HIGH,
+            "GCP JSON credentials");
   }
 
   @Override

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -115,9 +115,16 @@ public class CloudPubSubSinkTask extends SinkTask {
     includeMetadata = (Boolean) validatedProps.get(CloudPubSubSinkConnector.PUBLISH_KAFKA_METADATA);
     gcpCredentialsProvider = new ConnectorCredentialsProvider();
     String credentialsPath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    String credentialsJson = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
     if (credentialsPath != null) {
       try {
         gcpCredentialsProvider.loadFromFile(credentialsPath);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    } else if (credentialsJson != null) {
+      try {
+        gcpCredentialsProvider.loadJson(credentialsJson);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -18,19 +18,15 @@ package com.google.pubsub.kafka.sink;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.batching.BatchingSettings;
-import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.kafka.common.ConnectorUtils;
+import com.google.pubsub.kafka.common.ConnectorCredentialsProvider;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -73,7 +69,7 @@ public class CloudPubSubSinkTask extends SinkTask {
   private int maxRequestTimeoutMs;
   private int maxTotalTimeoutMs;
   private boolean includeMetadata;
-  private String gcpCredentialsFilePath;
+  private ConnectorCredentialsProvider gcpCredentialsProvider;
   private com.google.cloud.pubsub.v1.Publisher publisher;
 
   /** Holds a list of the publishing futures that have not been processed for a single partition. */
@@ -117,7 +113,15 @@ public class CloudPubSubSinkTask extends SinkTask {
         (Integer) validatedProps.get(CloudPubSubSinkConnector.MAX_TOTAL_TIMEOUT_MS);
     messageBodyName = (String) validatedProps.get(CloudPubSubSinkConnector.CPS_MESSAGE_BODY_NAME);
     includeMetadata = (Boolean) validatedProps.get(CloudPubSubSinkConnector.PUBLISH_KAFKA_METADATA);
-    gcpCredentialsFilePath = (String) validatedProps.get(CloudPubSubSinkConnector.GCP_CREDENTIALS_FILE_PATH);
+    gcpCredentialsProvider = new ConnectorCredentialsProvider();
+    String credentialsPath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    if (credentialsPath != null) {
+      try {
+        gcpCredentialsProvider.loadFromFile(credentialsPath);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
     if (publisher == null) {
       // Only do this if we did not use the constructor.
       createPublisher();
@@ -304,32 +308,11 @@ public class CloudPubSubSinkTask extends SinkTask {
     outstandingFutures.futures.add(publisher.publish(message));
   }
 
-  class GcpCredentialProvider implements CredentialsProvider {
-    private final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
-            ImmutableList.<String>builder()
-                    .add("https://www.googleapis.com/auth/cloud-platform")
-                    .add("https://www.googleapis.com/auth/pubsub")
-                    .build();
-    private String credentialPath;
-
-    public GcpCredentialProvider(String credentialPath) {
-      this.credentialPath = credentialPath;
-    }
-
-    @Override
-    public Credentials getCredentials() throws IOException {
-      GoogleCredentials googleCredentials = credentialPath == null ? GoogleCredentials.getApplicationDefault() :
-              GoogleCredentials.fromStream(new FileInputStream(credentialPath));
-      googleCredentials.createScoped(DEFAULT_SERVICE_SCOPES);
-      return googleCredentials;
-    }
-  }
-
   private void createPublisher() {
     ProjectTopicName fullTopic = ProjectTopicName.of(cpsProject, cpsTopic);
     com.google.cloud.pubsub.v1.Publisher.Builder builder =
         com.google.cloud.pubsub.v1.Publisher.newBuilder(fullTopic)
-            .setCredentialsProvider(new GcpCredentialProvider(gcpCredentialsFilePath))
+            .setCredentialsProvider(gcpCredentialsProvider)
             .setBatchingSettings(
                 BatchingSettings.newBuilder()
                     .setDelayThreshold(Duration.ofMillis(maxDelayThresholdMs))

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubGRPCSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubGRPCSubscriber.java
@@ -15,6 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.google.pubsub.kafka.source;
 
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
 import com.google.pubsub.kafka.common.ConnectorUtils;
@@ -39,11 +40,11 @@ public class CloudPubSubGRPCSubscriber implements CloudPubSubSubscriber {
   private long nextSubscriberResetTime = 0;
   private SubscriberFutureStub subscriber;
   private Random rand = new Random(System.currentTimeMillis());
-  private String gcpCredentialsFilePath;
+  private CredentialsProvider gcpCredentialsProvider;
 
-  CloudPubSubGRPCSubscriber(String gcpCredentialsFilePath) {
+  CloudPubSubGRPCSubscriber(CredentialsProvider gcpCredentialsProvider) {
+    this.gcpCredentialsProvider = gcpCredentialsProvider;
     makeSubscriber();
-    this.gcpCredentialsFilePath = gcpCredentialsFilePath;
   }
 
   public ListenableFuture<PullResponse> pull(PullRequest request) {
@@ -63,7 +64,7 @@ public class CloudPubSubGRPCSubscriber implements CloudPubSubSubscriber {
   private void makeSubscriber() {
     try {
       log.info("Creating subscriber.");
-      subscriber = SubscriberGrpc.newFutureStub(ConnectorUtils.getChannel(gcpCredentialsFilePath));
+      subscriber = SubscriberGrpc.newFutureStub(ConnectorUtils.getChannel(gcpCredentialsProvider));
       // We change the subscriber every 25 - 35 minutes in order to avoid GOAWAY errors.
       nextSubscriberResetTime =
           System.currentTimeMillis() + rand.nextInt(10 * 60 * 1000) + 25 * 60 * 1000;

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubRoundRobinSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubRoundRobinSubscriber.java
@@ -15,6 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.google.pubsub.kafka.source;
 
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
 import com.google.pubsub.v1.AcknowledgeRequest;
@@ -32,10 +33,10 @@ public class CloudPubSubRoundRobinSubscriber implements CloudPubSubSubscriber {
   private List<CloudPubSubSubscriber> subscribers;
   private int currentSubscriberIndex = 0;
 
-  public CloudPubSubRoundRobinSubscriber(int subscriberCount, String gcpCredentialsFilePath) {
+  public CloudPubSubRoundRobinSubscriber(int subscriberCount, CredentialsProvider gcpCredentialsProvider) {
     subscribers = new ArrayList<>();
     for (int i = 0; i < subscriberCount; ++i) {
-      subscribers.add(new CloudPubSubGRPCSubscriber(gcpCredentialsFilePath));
+      subscribers.add(new CloudPubSubGRPCSubscriber(gcpCredentialsProvider));
     }
   }
 

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -123,6 +123,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
     String cpsProject = props.get(ConnectorUtils.CPS_PROJECT_CONFIG);
     String cpsSubscription = props.get(CPS_SUBSCRIPTION_CONFIG);
     String credentialsPath = props.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    String credentialsJson = props.get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
     ConnectorCredentialsProvider credentialsProvider = new ConnectorCredentialsProvider();
     if (credentialsPath != null) {
       try {
@@ -130,7 +131,14 @@ public class CloudPubSubSourceConnector extends SourceConnector {
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
+    } else if (credentialsJson != null) {
+      try {
+        credentialsProvider.loadJson(credentialsJson);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
+
     verifySubscription(cpsProject, cpsSubscription, credentialsProvider);
     this.props = props;
     log.info("Started the CloudPubSubSourceConnector");
@@ -210,7 +218,13 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             Type.STRING,
             null,
             Importance.HIGH,
-            "The path to the GCP credentials file");
+            "The path to the GCP credentials file")
+        .define(
+            ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG,
+            Type.STRING,
+            null,
+            Importance.HIGH,
+            "GCP JSON credentials");
   }
 
   /**

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -23,12 +23,14 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.protobuf.util.Timestamps;
 import com.google.pubsub.kafka.common.ConnectorUtils;
+import com.google.pubsub.kafka.common.ConnectorCredentialsProvider;
 import com.google.pubsub.kafka.source.CloudPubSubSourceConnector.PartitionScheme;
 import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -70,7 +72,7 @@ public class CloudPubSubSourceTask extends SourceTask {
   private CloudPubSubSubscriber subscriber;
   private Set<String> ackIdsInFlight = Collections.synchronizedSet(new HashSet<String>());
   private final Set<String> standardAttributes = new HashSet<>();
-  private String gcpCredentialsFilePath;
+  private ConnectorCredentialsProvider gcpCredentialsProvider;
 
   public CloudPubSubSourceTask() {}
 
@@ -104,10 +106,18 @@ public class CloudPubSubSourceTask extends SourceTask {
     kafkaPartitionScheme =
         PartitionScheme.getEnum(
             (String) validatedProps.get(CloudPubSubSourceConnector.KAFKA_PARTITION_SCHEME_CONFIG));
-    gcpCredentialsFilePath = (String) validatedProps.get(CloudPubSubSourceConnector.GCP_CREDENTIALS_FILE_PATH);
+    gcpCredentialsProvider = new ConnectorCredentialsProvider();
+    String gcpCredentialsFilePath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    if (gcpCredentialsFilePath != null) {
+      try {
+        gcpCredentialsProvider.loadFromFile(gcpCredentialsFilePath);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
     if (subscriber == null) {
       // Only do this if we did not set through the constructor.
-      subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS, gcpCredentialsFilePath);
+      subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS, gcpCredentialsProvider);
     }
     standardAttributes.add(kafkaMessageKeyAttribute);
     standardAttributes.add(kafkaMessageTimestampAttribute);

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -108,9 +108,16 @@ public class CloudPubSubSourceTask extends SourceTask {
             (String) validatedProps.get(CloudPubSubSourceConnector.KAFKA_PARTITION_SCHEME_CONFIG));
     gcpCredentialsProvider = new ConnectorCredentialsProvider();
     String gcpCredentialsFilePath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    String credentialsJson = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
     if (gcpCredentialsFilePath != null) {
       try {
         gcpCredentialsProvider.loadFromFile(gcpCredentialsFilePath);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    } else if (credentialsJson != null) {
+      try {
+        gcpCredentialsProvider.loadJson(credentialsJson);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnectorTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnectorTest.java
@@ -16,12 +16,14 @@
 package com.google.pubsub.kafka.source;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
 import com.google.pubsub.kafka.common.ConnectorUtils;
+import com.google.pubsub.kafka.common.ConnectorCredentialsProvider;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +54,7 @@ public class CloudPubSubSourceConnectorTest {
 
   @Test(expected = ConnectException.class)
   public void testStartWhenSubscriptionNonexistant() {
-    doThrow(new ConnectException("")).when(connector).verifySubscription(anyString(), anyString(), anyString());
+    doThrow(new ConnectException("")).when(connector).verifySubscription(anyString(), anyString(), any(ConnectorCredentialsProvider.class));
     connector.start(props);
   }
 
@@ -63,7 +65,7 @@ public class CloudPubSubSourceConnectorTest {
 
   @Test
   public void testTaskConfigs() {
-    doNothing().when(connector).verifySubscription(anyString(), anyString(), anyString());
+    doNothing().when(connector).verifySubscription(anyString(), anyString(), any(ConnectorCredentialsProvider.class));
     connector.start(props);
     List<Map<String, String>> taskConfigs = connector.taskConfigs(NUM_TASKS);
     assertEquals(taskConfigs.size(), NUM_TASKS);


### PR DESCRIPTION
Add support for passing in JSON credentials via connector config key 'gcp.credentials.json'.