### PR TITLE
Convert Structs to JSON When Publishing

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -98,6 +98,7 @@ Connector supports the following configs:
 |---------------|-------------|-----------------------|------------------------------------------------------------------------------------------------------------------------------------|
 | cps.topic | String | REQUIRED (No default) | The topic in Cloud Pub/Sub to publish to, e.g. "foo" for topic "/projects/bar/topics/foo". |
 | cps.project | String | REQUIRED (No default) | The project in Cloud Pub/Sub containing the topic, e.g. "bar" from above. |
+| cps.struct.to.json | Boolean | false | Whether to convert Structs to JSON when publishing to Pub/Sub | 
 | maxBufferSize | Integer | 100 | The maximum number of messages that can be received for the messages on a topic partition before publishing them to Cloud Pub/Sub. |
 | maxBufferBytes | Long | 10000000 | The maximum number of bytes that can be received for the messages on a topic partition before publishing them to Cloud Pub/Sub. |
 | maxDelayThresholdMs | Integer | 100 | The maximum amount of time to wait to reach maxBufferSize or maxBufferBytes before publishing outstanding messages to Cloud Pub/Sub. |

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>2.1.0</version>
+      <version>1.1.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-json</artifactId>
-      <version>2.1.0</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -13,6 +13,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>connect-json</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -59,7 +64,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>0.10.2.1</version>
+      <version>2.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -44,6 +44,7 @@ public class ConnectorUtils {
   public static final String KAFKA_PARTITION_ATTRIBUTE = "kafka.partition";
   public static final String KAFKA_OFFSET_ATTRIBUTE = "kafka.offset";
   public static final String KAFKA_TIMESTAMP_ATTRIBUTE = "kafka.timestamp";
+  public static final String STRUCT_TO_JSON = "cps.struct.to.json";
 
   /** Return {@link io.grpc.Channel} which is used by Cloud Pub/Sub gRPC API's. */
   public static Channel getChannel(CredentialsProvider credentialsProvider) throws IOException {

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -153,7 +153,12 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             Type.STRING,
             null,
             Importance.HIGH,
-            "GCP JSON credentials");
+            "GCP JSON credentials")
+        .define(ConnectorUtils.STRUCT_TO_JSON,
+            Type.BOOLEAN,
+            false,
+            Importance.LOW,
+            "Weather to publish structs as JSON");
   }
 
   @Override


### PR DESCRIPTION
- Add "cps.struct.to.json" option allowing users to publish Structs as JSON
- Update org.apache.kafka connect-api version so we can use the connect-json kafka converter