### PR TITLE
Fix too many acks

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -89,8 +89,8 @@ Connector supports the following configs:
 | kafka.key.attribute | String | null | The Cloud Pub/Sub message attribute to use as a key for messages published to Kafka. |
 | kafka.partition.count | Integer | 1 | The number of Kafka partitions for the Kafka topic in which messages will be published to. NOTE: this parameter is ignored if partition scheme is "kafka_partitioner".|
 | kafka.partition.scheme | round_robin, hash_key, hash_value, kafka_partitioner | round_robin | The scheme for assigning a message to a partition in Kafka. The scheme "round_robin" assigns partitions in a round robin fashion, while the schemes "hash_key" and "hash_value" find the partition by hashing the message key and message value respectively. "kafka_partitioner" scheme delegates partitioning logic to kafka producer, which by default detects number of partitions automatically and performs either murmur hash based partition mapping or round robin depending on whether message key is provided or not.|
-| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
-| gcp.credentials.json | String | Optional | GCP credentials JSON blob | If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
+| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials. If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
+| gcp.credentials.json | String | Optional | GCP credentials JSON blob. If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
 
 #### Sink Connector
 
@@ -103,8 +103,8 @@ Connector supports the following configs:
 | maxDelayThresholdMs | Integer | 100 | The maximum amount of time to wait to reach maxBufferSize or maxBufferBytes before publishing outstanding messages to Cloud Pub/Sub. |
 | maxRequestTimeoutMs | Integer | 10000 | The timeout for individual publish requests to Cloud Pub/Sub. |
 | maxTotalTimeoutMs | Integer | 60000| The total timeout for a call to publish (including retries) to Cloud Pub/Sub. |
-| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials.| If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
-| gcp.credentials.json | String | Optional | GCP credentials JSON blob | If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
+| gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials. If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
+| gcp.credentials.json | String | Optional | GCP credentials JSON blob. If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
 
 #### Schema Support and Data Model
 

--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -91,6 +91,9 @@ Connector supports the following configs:
 | kafka.partition.scheme | round_robin, hash_key, hash_value, kafka_partitioner | round_robin | The scheme for assigning a message to a partition in Kafka. The scheme "round_robin" assigns partitions in a round robin fashion, while the schemes "hash_key" and "hash_value" find the partition by hashing the message key and message value respectively. "kafka_partitioner" scheme delegates partitioning logic to kafka producer, which by default detects number of partitions automatically and performs either murmur hash based partition mapping or round robin depending on whether message key is provided or not.|
 | gcp.credentials.file.path | String | Optional | The file path, which stores GCP credentials. If not defined, GOOGLE_APPLICATION_CREDENTIALS env is used. |
 | gcp.credentials.json | String | Optional | GCP credentials JSON blob. If specified, use the explicitly handed credentials. Consider using the externalized secrets feature in Kafka Connect for passing the value. |
+| max.ack.batch.size | Integer | 1000 | The maximum number of ack ids to batch per ack request to Cloud Pub/Sub. |
+| max.messages.in.flight | Integer | 10000000 | The maximum number of unacknowledged messages per task. |
+| backoff.pull.interval.ms | Long | 1000 | Time in milliseconds to wait between polls in case the maximum number of unacknowledged messages has been reached. |
 
 #### Sink Connector
 

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -9,7 +9,17 @@
   <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-</properties>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>22.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -17,6 +27,10 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -65,7 +79,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.24.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>22.0</version>
+        <version>20.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -54,9 +54,15 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public static final String KAFKA_TOPIC_CONFIG = "kafka.topic";
   public static final String CPS_SUBSCRIPTION_CONFIG = "cps.subscription";
   public static final String CPS_MAX_BATCH_SIZE_CONFIG = "cps.maxBatchSize";
+  public static final String MAX_ACK_BATCH_SIZE_CONFIG = "max.ack.batch.size";
+  public static final String MAX_MESSAGES_IN_FLIGHT_CONFIG = "max.messages.in.flight";
+  public static final String BACKOFF_PULL_INTERVAL_MS_CONFIG = "backoff.pull.interval.ms";
   public static final int DEFAULT_CPS_MAX_BATCH_SIZE = 100;
   public static final int DEFAULT_KAFKA_PARTITIONS = 1;
   public static final String DEFAULT_KAFKA_PARTITION_SCHEME = "round_robin";
+  public static final int DEFAULT_MAX_ACK_BATCH_SIZE = 1000;
+  public static final int DEFAULT_MAX_MESSAGES_IN_FLIGHT = 10000000;
+  public static final int DEFAULT_BACKOFF_PULL_INTERVAL_MS = 1000;
 
   /** Defines the accepted values for the {@link #KAFKA_PARTITION_SCHEME_CONFIG}. */
   public enum PartitionScheme {
@@ -184,7 +190,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             DEFAULT_CPS_MAX_BATCH_SIZE,
             ConfigDef.Range.between(1, Integer.MAX_VALUE),
             Importance.MEDIUM,
-            "The minimum number of messages to batch per pull request to Cloud Pub/Sub.")
+            "The maximum number of messages to batch per pull request to Cloud Pub/Sub.")
         .define(
             KAFKA_MESSAGE_KEY_CONFIG,
             Type.STRING,
@@ -224,7 +230,28 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             Type.STRING,
             null,
             Importance.HIGH,
-            "GCP JSON credentials");
+            "GCP JSON credentials")
+        .define(
+            MAX_ACK_BATCH_SIZE_CONFIG,
+            Type.INT,
+            DEFAULT_MAX_ACK_BATCH_SIZE,
+            ConfigDef.Range.between(1, Integer.MAX_VALUE),
+            Importance.MEDIUM,
+            "The maximum number of ack ids to batch per ack request to Cloud Pub/Sub.")
+        .define(
+            MAX_MESSAGES_IN_FLIGHT_CONFIG,
+            Type.INT,
+            DEFAULT_MAX_MESSAGES_IN_FLIGHT,
+            ConfigDef.Range.between(1, Integer.MAX_VALUE),
+            Importance.MEDIUM,
+            "The maximum number of unacknowledged messages per task.")
+        .define(
+            BACKOFF_PULL_INTERVAL_MS_CONFIG,
+            Type.LONG,
+            DEFAULT_BACKOFF_PULL_INTERVAL_MS,
+            ConfigDef.Range.between(1, Integer.MAX_VALUE),
+            Importance.MEDIUM,
+            "Time in milliseconds to wait between polls in case the maximum number of unacknowledged messages has been reached.");
   }
 
   /**

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -32,12 +32,16 @@ import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -46,6 +50,9 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Collections.synchronizedList;
 
 /**
  * A {@link SourceTask} used by a {@link CloudPubSubSourceConnector} to write messages to <a
@@ -64,15 +71,23 @@ public class CloudPubSubSourceTask extends SourceTask {
   private int kafkaPartitions;
   private PartitionScheme kafkaPartitionScheme;
   private int cpsMaxBatchSize;
+  private int maxAckBatchSize;
+  private int maxMessagesInFlight;
+  private long backOffPullIntervalMs;
   // Keeps track of the current partition to publish to if the partition scheme is round robin.
   private int currentRoundRobinPartition = -1;
-  // Keep track of all ack ids that have not been sent correctly acked yet.
-  private Set<String> deliveredAckIds = Collections.synchronizedSet(new HashSet<String>());
-  private Set<String> ackIds = Collections.synchronizedSet(new HashSet<String>());
-  private CloudPubSubSubscriber subscriber;
+  //Ack ids of messages that have been pulled but not yet delivered to kafka.
+  private Set<String> ackIdsPulled = Collections.synchronizedSet(new HashSet<String>());
+  // Ack ids of messages that have been delivered to kafka, but not attempted to be acknowledged in pubsub.
+  private final Set<String> ackIdsOfMessagesDeliveredToKafka = Collections.synchronizedSet(new HashSet<String>());
+  //Ack ids that are being sent to pubsub, but has not yet been acknowledged yet.
   private Set<String> ackIdsInFlight = Collections.synchronizedSet(new HashSet<String>());
+
   private final Set<String> standardAttributes = new HashSet<>();
+  private CloudPubSubSubscriber subscriber;
   private ConnectorCredentialsProvider gcpCredentialsProvider;
+
+  private final Object ackMutex = new Object();
 
   public CloudPubSubSourceTask() {}
 
@@ -97,6 +112,9 @@ public class CloudPubSubSourceTask extends SourceTask {
     kafkaTopic = validatedProps.get(CloudPubSubSourceConnector.KAFKA_TOPIC_CONFIG).toString();
     cpsMaxBatchSize =
         (Integer) validatedProps.get(CloudPubSubSourceConnector.CPS_MAX_BATCH_SIZE_CONFIG);
+    maxAckBatchSize = (Integer) validatedProps.get(CloudPubSubSourceConnector.MAX_ACK_BATCH_SIZE_CONFIG);
+    maxMessagesInFlight = (Integer) validatedProps.get(CloudPubSubSourceConnector.MAX_MESSAGES_IN_FLIGHT_CONFIG);
+    backOffPullIntervalMs = (Long) validatedProps.get(CloudPubSubSourceConnector.BACKOFF_PULL_INTERVAL_MS_CONFIG);
     kafkaPartitions =
         (Integer) validatedProps.get(CloudPubSubSourceConnector.KAFKA_PARTITIONS_CONFIG);
     kafkaMessageKeyAttribute =
@@ -133,8 +151,14 @@ public class CloudPubSubSourceTask extends SourceTask {
 
   @Override
   public List<SourceRecord> poll() throws InterruptedException {
-    ackMessages();
-    log.debug("Polling...");
+    int numberOfInflightMessages  = getInFlightMessagesCount();
+    if (numberOfInflightMessages > maxMessagesInFlight) {
+      log.warn("Number of inflight messages is to high ({} > {}). Skip polling. Sleeping for {} ms.", numberOfInflightMessages, maxMessagesInFlight, backOffPullIntervalMs);
+      Thread.sleep(backOffPullIntervalMs);
+      return Collections.emptyList();
+    }
+
+    log.trace("Polling...");
     PullRequest request =
         PullRequest.newBuilder()
             .setSubscription(cpsSubscription)
@@ -144,17 +168,17 @@ public class CloudPubSubSourceTask extends SourceTask {
     try {
       PullResponse response = subscriber.pull(request).get();
       List<SourceRecord> sourceRecords = new ArrayList<>();
-      log.trace("Received " + response.getReceivedMessagesList().size() + " messages");
+      log.debug("Received {} messages. Total number of inflight messages before pull: {}", response.getReceivedMessagesList().size(), numberOfInflightMessages);
       for (ReceivedMessage rm : response.getReceivedMessagesList()) {
         PubsubMessage message = rm.getMessage();
         String ackId = rm.getAckId();
         // If we are receiving this message a second (or more) times because the ack for it failed
         // then do not create a SourceRecord for this message. In case we are waiting for ack
         // response we also skip the message
-        if (ackIds.contains(ackId) || deliveredAckIds.contains(ackId) || ackIdsInFlight.contains(ackId)) {
+        if (isAlreadyInFlight(ackId)) {
           continue;
         }
-        ackIds.add(ackId);
+        ackIdsPulled.add(ackId);
         Map<String, String> messageAttributes = message.getAttributes();
         String key = messageAttributes.get(kafkaMessageKeyAttribute);
         Long timestamp = getLongValue(messageAttributes.get(kafkaMessageTimestampAttribute));
@@ -220,48 +244,137 @@ public class CloudPubSubSourceTask extends SourceTask {
       }
       return sourceRecords;
     } catch (Exception e) {
-      log.info("Error while retrieving records, treating as an empty poll. " + e);
+      log.warn("Error while retrieving records, treating as an empty poll. " + e);
       return new ArrayList<>();
     }
   }
 
+  /**
+   * Returns number of messages that has been pulled, but not yet acknowledged.
+   */
+  int getInFlightMessagesCount() {
+    return ackIdsPulled.size() + ackIdsOfMessagesDeliveredToKafka.size() + ackIdsInFlight.size();
+  }
+
+  /**
+   * Checks if message has already ben delivered for processing. Does not guarantee duplicate detection,
+   * since the message might not be in any of the collections being checked already.
+   */
+  boolean isAlreadyInFlight(String ackId) {
+    return ackIdsPulled.contains(ackId) || ackIdsOfMessagesDeliveredToKafka.contains(ackId) || ackIdsInFlight.contains(ackId);
+  }
+
+
   @Override
-  public void commit() throws InterruptedException {
+  public void commit() {
     ackMessages();
   }
 
   /**
-   * Attempt to ack all ids in {@link #deliveredAckIds}.
+   * Attempt to ack all ids in {@link #ackIdsOfMessagesDeliveredToKafka}.
+   * Blocks until all ack requests succeed.
    */
   private void ackMessages() {
-    if (deliveredAckIds.size() != 0) {
-      AcknowledgeRequest.Builder requestBuilder = AcknowledgeRequest.newBuilder()
-          .setSubscription(cpsSubscription);
-      final Set<String> ackIdsBatch = new HashSet<>();
-      synchronized (deliveredAckIds) {
-        requestBuilder.addAllAckIds(deliveredAckIds);
-        ackIdsInFlight.addAll(deliveredAckIds);
-        ackIdsBatch.addAll(deliveredAckIds);
-        deliveredAckIds.clear();
+    if (ackIdsOfMessagesDeliveredToKafka.isEmpty())
+      return;
+
+    List<Set<String>> ackIdBatches;
+
+    long startTimestamp = System.currentTimeMillis();
+    int numberOfAcks;
+    synchronized (ackMutex) {
+      numberOfAcks = ackIdsOfMessagesDeliveredToKafka.size();
+      ackIdBatches = split(ackIdsOfMessagesDeliveredToKafka, maxAckBatchSize);
+      ackIdsInFlight.addAll(ackIdsOfMessagesDeliveredToKafka);
+      ackIdsOfMessagesDeliveredToKafka.clear();
+    }
+
+    int ackAttempt = 0;
+    while (!ackIdBatches.isEmpty()) {
+      ack(ackIdBatches);
+      if (!ackIdBatches.isEmpty()) {
+        ++ackAttempt;
+        log.warn("Have {} batches to ack after {} attempts.", ackIdBatches.size(), ackAttempt);
       }
-      ListenableFuture<Empty> response = subscriber.ackMessages(requestBuilder.build());
+    }
+
+    log.debug("Have acked {} messages in {} ms", numberOfAcks, System.currentTimeMillis() - startTimestamp );
+  }
+
+  /**
+   * Issues {@link AcknowledgeRequest} for each batch. Waits for all request to complete.
+   * Removes successful batches from {@code ackBatches}
+   */
+  private void ack(final List<Set<String>> ackBatches) {
+    List<ListenableFuture<Empty>> ackResponses = new ArrayList<>(ackBatches.size());
+
+    final List<Set<String>> ackedBatches = synchronizedList(new ArrayList<Set<String>>());
+
+    for (final Set<String> ackIdsBatch : ackBatches) {
+      ListenableFuture<Empty> response = subscriber.ackMessages(
+          AcknowledgeRequest.newBuilder()
+              .setSubscription(cpsSubscription)
+              .addAllAckIds(ackIdsBatch)
+              .build()
+      );
+
+
       Futures.addCallback(
           response,
           new FutureCallback<Empty>() {
             @Override
             public void onSuccess(Empty result) {
-              ackIdsInFlight.removeAll(ackIdsBatch);
-              log.trace("Successfully acked a set of messages. {}", ackIdsBatch.size());
+              ackedBatches.add(ackIdsBatch);
+              log.trace("Successfully acked a set of messages of size {}.", ackIdsBatch.size());
             }
 
             @Override
             public void onFailure(Throwable t) {
-              deliveredAckIds.addAll(ackIdsBatch);
-              ackIdsInFlight.removeAll(ackIdsBatch);
-              log.error("An exception occurred acking messages: " + t);
+              log.error("An exception occurred acking messages. Batch will be retried.", t);
             }
-          });
+          }, directExecutor()
+      );
+
+      ackResponses.add(response);
     }
+
+    try {
+      Futures.whenAllComplete(ackResponses).call(
+          new Callable<Empty>() {
+            @Override
+            public Empty call() {
+              for (Set<String> ackedBatch : ackedBatches) {
+                ackIdsInFlight.removeAll(ackedBatch);
+              }
+              ackBatches.removeAll(ackedBatches);
+              log.debug("Successfully acked {} batches.", ackBatches.size());
+              return Empty.getDefaultInstance();
+            }
+          },
+          directExecutor()
+      ).get();
+    } catch (InterruptedException e) {
+      log.warn("Got interrupted while waiting for acknowledgements.");
+      Thread.currentThread().interrupt();
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Failed while acknowledging messages", e);
+    }
+  }
+
+  static List<Set<String>> split(Collection<String> ackIds, int batchSize) {
+      List<Set<String>> batches = new ArrayList<>();
+      int numberOfBatches = (ackIds.size() + batchSize -1) / batchSize ;
+
+      for (int i = 0; i < numberOfBatches; i++) {
+        batches.add(new HashSet<String>());
+      }
+
+      int idx = 0;
+      for (String ackId : ackIds) {
+        batches.get(idx ++ / batchSize).add(ackId);
+      }
+      return batches;
+
   }
 
   /** Return the partition a message should go to based on {@link #kafkaPartitionScheme}. */
@@ -296,8 +409,11 @@ public class CloudPubSubSourceTask extends SourceTask {
   @Override
   public void commitRecord(SourceRecord record) {
     String ackId = record.sourceOffset().get(cpsSubscription).toString();
-    deliveredAckIds.add(ackId);
-    ackIds.remove(ackId);
+    synchronized (ackMutex) {
+      ackIdsOfMessagesDeliveredToKafka.add(ackId);
+      ackIdsPulled.remove(ackId);
+    }
     log.trace("Committed {}", ackId);
   }
+
 }


### PR DESCRIPTION
This PR fixes 2 problems:
1. When number of ack ids gets larger then fit into single AcknowledgeRequest, connector cannot ack any message, gets those back and keeps writing duplicates to kafka.
2. commit method is supposed to wait until all messages are acked. Previously it was not, which could result in extra duplicates during connector restarts.