### PR TITLE
Allow Kafka Connect headers

### DIFF
--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>0.10.2.1</version>
+      <version>2.1.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>2.1.1</version>
+      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -50,6 +50,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final String CPS_MESSAGE_BODY_NAME = "messageBodyName";
   public static final String DEFAULT_MESSAGE_BODY_NAME = "cps_message_body";
   public static final String PUBLISH_KAFKA_METADATA = "metadata.publish";
+  public static final String PUBLISH_KAFKA_HEADERS = "headers.publish";
   private Map<String, String> props;
 
   @Override
@@ -138,6 +139,12 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             Importance.MEDIUM,
             "When true, include the Kafka topic, partition, offset, and timestamp as message "
                 + "attributes when a message is published to Cloud Pub/Sub.")
+        .define(
+            PUBLISH_KAFKA_HEADERS,
+            Type.BOOLEAN,
+            false,
+            Importance.MEDIUM,
+            "When true, include any headers as attributes when a message is published to Cloud Pub/Sub.")
         .define(CPS_MESSAGE_BODY_NAME,
             Type.STRING,
             DEFAULT_MESSAGE_BODY_NAME,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -29,12 +29,8 @@ import com.google.pubsub.v1.PubsubMessage;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -43,6 +39,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -69,6 +66,7 @@ public class CloudPubSubSinkTask extends SinkTask {
   private int maxRequestTimeoutMs;
   private int maxTotalTimeoutMs;
   private boolean includeMetadata;
+  private boolean includeHeaders;
   private ConnectorCredentialsProvider gcpCredentialsProvider;
   private com.google.cloud.pubsub.v1.Publisher publisher;
 
@@ -113,6 +111,7 @@ public class CloudPubSubSinkTask extends SinkTask {
         (Integer) validatedProps.get(CloudPubSubSinkConnector.MAX_TOTAL_TIMEOUT_MS);
     messageBodyName = (String) validatedProps.get(CloudPubSubSinkConnector.CPS_MESSAGE_BODY_NAME);
     includeMetadata = (Boolean) validatedProps.get(CloudPubSubSinkConnector.PUBLISH_KAFKA_METADATA);
+    includeHeaders = (Boolean) validatedProps.get(CloudPubSubSinkConnector.PUBLISH_KAFKA_HEADERS);
     gcpCredentialsProvider = new ConnectorCredentialsProvider();
     String credentialsPath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
     String credentialsJson = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
@@ -139,9 +138,9 @@ public class CloudPubSubSinkTask extends SinkTask {
   @Override
   public void put(Collection<SinkRecord> sinkRecords) {
     log.debug("Received " + sinkRecords.size() + " messages to send to CPS.");
-    PubsubMessage.Builder builder = PubsubMessage.newBuilder();
     for (SinkRecord record : sinkRecords) {
       log.trace("Received record: " + record.toString());
+      PubsubMessage.Builder builder = PubsubMessage.newBuilder();
       Map<String, String> attributes = new HashMap<>();
       ByteString value = handleValue(record.valueSchema(), record.value(), attributes);
       if (record.key() != null) {
@@ -154,6 +153,11 @@ public class CloudPubSubSinkTask extends SinkTask {
             ConnectorUtils.KAFKA_PARTITION_ATTRIBUTE, record.kafkaPartition().toString());
         attributes.put(ConnectorUtils.KAFKA_OFFSET_ATTRIBUTE, Long.toString(record.kafkaOffset()));
         attributes.put(ConnectorUtils.KAFKA_TIMESTAMP_ATTRIBUTE, record.timestamp().toString());
+      }
+      if (includeHeaders && record.headers() != null && !record.headers().isEmpty()) {
+        for (Header header : record.headers()) {
+          attributes.put(header.key(), header.value().toString());
+        }
       }
       PubsubMessage message = builder.setData(value).putAllAttributes(attributes).build();
       publishMessage(record.topic(), record.kafkaPartition(), message);


### PR DESCRIPTION
Version 1.1.0 introduced Headers to Kafka Connect which is used by some connectors such as Debezium. This change exposes a configuration item `headers.publish` modelled after `metadata.publish`. 