### PR TITLE
Update kafka-connect api to 2.1.0 and add support for ConnectHeaders

### DIFF
--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
-      <version>0.10.2.1</version>
+      <version>2.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -154,6 +157,11 @@ public class CloudPubSubSinkTask extends SinkTask {
             ConnectorUtils.KAFKA_PARTITION_ATTRIBUTE, record.kafkaPartition().toString());
         attributes.put(ConnectorUtils.KAFKA_OFFSET_ATTRIBUTE, Long.toString(record.kafkaOffset()));
         attributes.put(ConnectorUtils.KAFKA_TIMESTAMP_ATTRIBUTE, record.timestamp().toString());
+      }
+      final Iterator<Header> headerIterator = record.headers().iterator();
+      while(headerIterator.hasNext()) {
+        final Header recordHeader = headerIterator.next();
+        attributes.put(recordHeader.key(), String.valueOf(recordHeader.value()));
       }
       PubsubMessage message = builder.setData(value).putAllAttributes(attributes).build();
       publishMessage(record.topic(), record.kafkaPartition(), message);

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -178,29 +178,7 @@ public class CloudPubSubSourceTask extends SourceTask {
               headers.addString(attribute.getKey(), attribute.getValue());
             }
           }
-          /*SchemaBuilder valueSchemaBuilder = SchemaBuilder.struct().field(
-              ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD,
-              Schema.BYTES_SCHEMA);
 
-          for (Entry<String, String> attribute :
-               messageAttributes.entrySet()) {
-            if (!attribute.getKey().equals(kafkaMessageKeyAttribute)) {
-              valueSchemaBuilder.field(attribute.getKey(),
-                                       Schema.STRING_SCHEMA);
-            }
-          }
-
-          Schema valueSchema = valueSchemaBuilder.build();
-          Struct value =
-              new Struct(valueSchema)
-                  .put(ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD,
-                       messageBytes);
-          for (Field field : valueSchema.fields()) {
-            if (!field.name().equals(
-                    ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD)) {
-              value.put(field.name(), messageAttributes.get(field.name()));
-            }
-          }*/
           record =
             new SourceRecord(
                 null,

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,8 +26,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.Publisher;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.kafka.common.ConnectorUtils;
 import com.google.pubsub.v1.PubsubMessage;
@@ -47,6 +44,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -381,6 +379,55 @@ public class CloudPubSubSinkTaskTest {
     attributes2.put(ConnectorUtils.KAFKA_TIMESTAMP_ATTRIBUTE, "50001");
     expectedMessages.add(
         PubsubMessage.newBuilder().putAllAttributes(attributes2).setData(KAFKA_MESSAGE2).build());
+
+    assertEquals(requestArgs, expectedMessages);
+  }
+
+  /**
+   * Tests that when requested, Kafka metadata is included in the messages published to Cloud
+   * Pub/Sub.
+   */
+  @Test
+  public void testKafkaAttributes() {
+    props.put(CloudPubSubSinkConnector.PUBLISH_KAFKA_METADATA, "false");
+    props.put(CloudPubSubSinkConnector.MAX_BUFFER_SIZE_CONFIG, CPS_MIN_BATCH_SIZE1);
+    task.start(props);
+
+    String customHeader = "customHeader";
+    String customValue = "customValue";
+
+    Header header = mock(Header.class);
+    when(header.key()).thenReturn(customHeader);
+    when(header.value()).thenReturn(customValue);
+    List<Header> headers = new ArrayList<>();
+    headers.add(header);
+
+    List<SinkRecord> records = new ArrayList<SinkRecord>();
+    records.add(
+            new SinkRecord(
+                    KAFKA_TOPIC,
+                    4,
+                    STRING_SCHEMA,
+                    KAFKA_MESSAGE_KEY,
+                    BYTE_STRING_SCHEMA,
+                    KAFKA_MESSAGE1,
+                    1000,
+                    50000L,
+                    TimestampType.CREATE_TIME,
+                    headers));
+
+    task.put(records);
+    ArgumentCaptor<PubsubMessage> captor = ArgumentCaptor.forClass(PubsubMessage.class);
+    verify(publisher, times(1)).publish(captor.capture());
+    List<PubsubMessage> requestArgs = captor.getAllValues();
+
+    List<PubsubMessage> expectedMessages = new ArrayList<>();
+    Map<String, String> attributes1 = new HashMap<>();
+    attributes1.put(ConnectorUtils.CPS_MESSAGE_KEY_ATTRIBUTE, KAFKA_MESSAGE_KEY);
+    attributes1.put(customHeader, customValue);
+
+    expectedMessages.add(
+            PubsubMessage.newBuilder().putAllAttributes(attributes1).setData(KAFKA_MESSAGE1).build());
 
     assertEquals(requestArgs, expectedMessages);
   }

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Before;
 import org.junit.Test;
@@ -272,7 +273,7 @@ public class CloudPubSubSourceTaskTest {
     List<SourceRecord> result = task.poll();
     verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
     assertEquals(1, result.size());
-    Schema expectedSchema =
+    /*Schema expectedSchema =
         SchemaBuilder.struct()
             .field(ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD, Schema.BYTES_SCHEMA)
             .field("attribute1", Schema.STRING_SCHEMA)
@@ -291,7 +292,23 @@ public class CloudPubSubSourceTaskTest {
             Schema.OPTIONAL_STRING_SCHEMA,
             KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE,
             expectedSchema,
-            expectedValue);
+            expectedValue);*/
+    ConnectHeaders headers = new ConnectHeaders();
+    headers.addString("attribute1", "attribute_value1");
+    headers.addString("attribute2", "attribute_value2");
+
+    SourceRecord expected =
+            new SourceRecord(
+                    null,
+                    null,
+                    KAFKA_TOPIC,
+                    0,
+                    Schema.OPTIONAL_STRING_SCHEMA,
+                    KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE,
+                    Schema.BYTES_SCHEMA,
+                    KAFKA_VALUE,
+                    Long.parseLong(KAFKA_MESSAGE_TIMESTAMP_ATTRIBUTE_VALUE),
+                    headers);
     assertRecordsEqual(expected, result.get(0));
   }
 

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -273,26 +273,7 @@ public class CloudPubSubSourceTaskTest {
     List<SourceRecord> result = task.poll();
     verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
     assertEquals(1, result.size());
-    /*Schema expectedSchema =
-        SchemaBuilder.struct()
-            .field(ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD, Schema.BYTES_SCHEMA)
-            .field("attribute1", Schema.STRING_SCHEMA)
-            .field("attribute2", Schema.STRING_SCHEMA)
-            .build();
-    Struct expectedValue = new Struct(expectedSchema)
-                               .put(ConnectorUtils.KAFKA_MESSAGE_CPS_BODY_FIELD, KAFKA_VALUE)
-                               .put("attribute1", "attribute_value1")
-                               .put("attribute2", "attribute_value2");
-    SourceRecord expected =
-        new SourceRecord(
-            null,
-            null,
-            KAFKA_TOPIC,
-            0,
-            Schema.OPTIONAL_STRING_SCHEMA,
-            KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE,
-            expectedSchema,
-            expectedValue);*/
+
     ConnectHeaders headers = new ConnectHeaders();
     headers.addString("attribute1", "attribute_value1");
     headers.addString("attribute2", "attribute_value2");


### PR DESCRIPTION
Updating to kafka-api 2.1.0 allows us to use ConnectHeaders and this way match Kafka Headers to PubSub message attributes and vice versa