### PR TITLE
Fix threads leak on sink task stop by shutting down publisher

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -42,11 +42,13 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final String MAX_DELAY_THRESHOLD_MS = "delayThresholdMs";
   public static final String MAX_REQUEST_TIMEOUT_MS = "maxRequestTimeoutMs";
   public static final String MAX_TOTAL_TIMEOUT_MS = "maxTotalTimeoutMs";
+  public static final String MAX_SHUTDOWN_TIMEOUT_MS = "maxShutdownTimeoutMs";
   public static final int DEFAULT_MAX_BUFFER_SIZE = 100;
   public static final long DEFAULT_MAX_BUFFER_BYTES = 10000000L;
   public static final int DEFAULT_DELAY_THRESHOLD_MS = 100;
   public static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
   public static final int DEFAULT_TOTAL_TIMEOUT_MS = 60000;
+  public static final int DEFAULT_SHUTDOWN_TIMEOUT_MS = 60000;
   public static final String CPS_MESSAGE_BODY_NAME = "messageBodyName";
   public static final String DEFAULT_MESSAGE_BODY_NAME = "cps_message_body";
   public static final String PUBLISH_KAFKA_METADATA = "metadata.publish";
@@ -131,6 +133,14 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             Importance.MEDIUM,
             "The maximum amount of time to wait for a publish to complete (including retries) in "
                 + "Cloud Pub/Sub.")
+        .define(
+            MAX_SHUTDOWN_TIMEOUT_MS,
+            Type.INT,
+            DEFAULT_SHUTDOWN_TIMEOUT_MS,
+            ConfigDef.Range.between(10000, Integer.MAX_VALUE),
+            Importance.MEDIUM,
+            "The maximum amount of time to wait for a publisher to shutdown when stopping task "
+                + "in Kafka Connect.")
         .define(
             PUBLISH_KAFKA_METADATA,
             Type.BOOLEAN,

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -412,6 +412,18 @@ public class CloudPubSubSinkTaskTest {
     verify(goodFuture, times(2)).addListener(any(Runnable.class), any(Executor.class));
   }
 
+  @Test
+  public void testPublisherShutdownOnStop() throws Exception {
+    int maxShutdownTimeoutMs = 20000;
+    props.put(CloudPubSubSinkConnector.MAX_SHUTDOWN_TIMEOUT_MS, Integer.toString(maxShutdownTimeoutMs));
+
+    task.start(props);
+    task.stop();
+
+    verify(publisher, times(1)).shutdown();
+    verify(publisher, times(1)).awaitTermination(maxShutdownTimeoutMs, TimeUnit.MILLISECONDS);
+  }
+
   /** Get some sample SinkRecords's to use in the tests. */
   private List<SinkRecord> getSampleRecords() {
     List<SinkRecord> records = new ArrayList<>();


### PR DESCRIPTION
This change fixes PubSub connector leaking threads when there are periodic connector's configuration updates. On each configuration update Kafka Connect stops and starts connector tasks.

Before applying the change we observed ~120 threads at Kafka Connect's startup growing to 2k+ threads after a few hours of configuration updates.
After the change the day's worth of updates does not impact the number of Kafka Connect's threads and their numbers stays at ~120.

Fixes: #201 