### PR TITLE
fix: Do not drop all messages in the batch when receiving an empty message

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -182,7 +182,7 @@ public class CloudPubSubSinkTask extends SinkTask {
         SettableApiFuture<String> nullMessageFuture = SettableApiFuture.<String>create();
         nullMessageFuture.set("No message");
         addPendingMessageFuture(record.topic(), record.kafkaPartition(), nullMessageFuture);
-        return;
+        continue;
       }
       PubsubMessage.Builder builder = PubsubMessage.newBuilder();
       builder.putAllAttributes(attributes);


### PR DESCRIPTION
Instead, only drop the single message received.