### PR TITLE
feat: Implement copy_tool

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -15,13 +15,6 @@ to Pub/Sub Lite.
 PubSubLiteSourceConnector provides a source connector to copy messages from
 Pub/Sub Lite to Kafka.
 
-### Acquring the connector
-
-A pre-built uber-jar is available for download with the
-[latest release](https://github.com/GoogleCloudPlatform/pubsub/releases).
-
-You can also build the connector from head, as described [below](#building).
-
 ### Pre-Running Steps
 
 1.  Regardless of whether you are running on Google Cloud Platform or not, you
@@ -43,6 +36,39 @@ You can also build the connector from head, as described [below](#building).
     export this environment variable as part of your shell startup file).
 
     `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key/file`
+    
+### Quickstart: copy_tool.py
+
+You can download `copy_tool.py`, a single-file python script which downloads,
+sets up and runs the kafka connector in a single-machine configuration. This
+script requires:
+
+1. python >= 3.5
+1. [requests](https://requests.readthedocs.io/en/master/user/install/#python-m-pip-install-requests)
+   installed
+1. `JAVA_HOME` configured properly
+1. `GOOGLE_APPLICATION_CREDENTIALS` set
+1. A [properties file](#cloudpubsubconnector-configs) with connector.class and
+   other properties set
+   
+It can be invoked on mac/linux with:
+
+```bash
+python3 path/to/copy_tool.py --bootstrap_servers=MY_KAFKA_SERVER,OTHER_SERVER --connector_properties_file=path/to/connector.properties
+```
+
+or windows with:
+
+```bash
+python3 path\to\copy_tool.py --bootstrap_servers=MY_KAFKA_SERVER,OTHER_SERVER --connector_properties_file=path\to\connector.properties
+```
+
+### Acquiring the connector
+
+A pre-built uber-jar is available for download with the
+[latest release](https://github.com/GoogleCloudPlatform/pubsub/releases).
+
+You can also build the connector from head, as described [below](#building).
 
 ### Running a Connector
 

--- a/kafka-connector/config/pubsub-lite-source-connector.properties
+++ b/kafka-connector/config/pubsub-lite-source-connector.properties
@@ -1,5 +1,5 @@
 name=PubSubLiteSourceConnector
-connector.class=com.google.pubsublite.kafka.sink.PubSubLiteSourceConnector
+connector.class=com.google.pubsublite.kafka.source.PubSubLiteSourceConnector
 tasks.max=10
 pubsublite.project=my-project
 pubsublite.location=europe-south7-q

--- a/kafka-connector/copy_tool.py
+++ b/kafka-connector/copy_tool.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+"""Pub/Sub <-> Kafka Simple Copy Tool
+
+A python script for downloading, installing and running the Kafka connector in
+a single machine configuration. More complex set-ups should look at the kafka
+connect documentation
+(https://docs.confluent.io/home/connect/userguide.html).
+"""
+
+import argparse
+import io
+import os
+import platform
+import requests
+import tarfile
+import tempfile
+import subprocess
+
+KAFKA_RELEASE = "2.6.0"
+KAFKA_FOLDER = f"kafka_2.13-{KAFKA_RELEASE}"
+KAFKA_LINK = f"https://downloads.apache.org/kafka/{KAFKA_RELEASE}/{KAFKA_FOLDER}.tgz"
+
+CONNECTOR_RELEASE = "v0.5-alpha"
+PUBSUB_CONNECTOR_LINK = f"https://github.com/GoogleCloudPlatform/pubsub/releases/download/{CONNECTOR_RELEASE}/pubsub-kafka-connector.jar"
+
+
+def extract_kafka_to(tempdir):
+    response = requests.get(KAFKA_LINK)
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode='r:gz') as archive:
+        archive.extractall(path=tempdir)
+
+
+def get_connector(tempdir):
+    response = requests.get(PUBSUB_CONNECTOR_LINK)
+    with open(os.path.join(tempdir, "pubsub-kafka-connector.jar"), 'wb+') as f:
+        f.write(response.content)
+
+
+def download(tempdir):
+    print("Downloading kafka...")
+    kafka_path = os.path.join(tempdir, "kafka")
+    os.mkdir(kafka_path)
+    extract_kafka_to(kafka_path)
+    print("Downloading connector...")
+    connector_path = os.path.join(tempdir, "connector")
+    os.mkdir(connector_path)
+    get_connector(connector_path)
+
+
+def make_connect_config(tempdir, bootstrap_servers):
+    print("Building connect config...")
+    with open(os.path.join(tempdir, "connect_config.properties"),
+              'w+') as output:
+        output.write(
+            "key.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n")
+        output.write(
+            "value.converter=org.apache.kafka.connect.converters.ByteArrayConverter\n")
+        output.write(f"bootstrap.servers={bootstrap_servers}\n")
+        connector_dir = os.path.join(tempdir, "connector")
+        output.write(f"plugin.path={connector_dir}\n")
+        offset_file = os.path.join(tempdir, "connect.offset")
+        output.write(f"offset.storage.file.filename={offset_file}\n")
+
+
+def run_connector(tempdir, connector_properties):
+    if platform.system() == "Windows":
+        kafka_script = os.path.join(tempdir, "kafka", KAFKA_FOLDER, "bin",
+                                    "windows", "connect-standalone.bat")
+    else:
+        kafka_script = os.path.join(tempdir, "kafka", KAFKA_FOLDER, "bin",
+                                    "connect-standalone.sh")
+    connect_properties = os.path.join(tempdir, "connect_config.properties")
+    print("Running")
+    subprocess.run(
+        args=[kafka_script, connect_properties, connector_properties],
+        cwd=tempdir)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bootstrap_servers",
+        type=str,
+        required=True,
+        help="A comma-separated list of kafka servers to use for bootstrapping."
+    )
+    parser.add_argument(
+        "--connector_properties_file",
+        type=str,
+        required=True,
+        help="""The Pub/Sub connector configuration file.
+        
+        `connector.class` specifies which connector to use.
+        Other arguments to this configuration may be found at
+        https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector#cloudpubsubconnector-configs
+        """)
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory() as tempdir:
+        download(tempdir)
+        make_connect_config(tempdir, args.bootstrap_servers)
+        run_connector(tempdir, args.connector_properties_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/load-test-framework/flic.iml
+++ b/load-test-framework/flic.iml
@@ -2,7 +2,7 @@
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Python" name="Python">
-      <configuration sdkName="Python 3.7 (load-test-framework)" />
+      <configuration sdkName="Python 3.6" />
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
@@ -21,7 +21,6 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Bundled Protobuf Distribution" level="application" />
-    <orderEntry type="library" name="Python 3.7 (load-test-framework) interpreter library" level="application" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.13.1" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
@@ -94,5 +93,6 @@
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-api:0.18.0" level="project" />
     <orderEntry type="library" name="Maven: io.opencensus:opencensus-contrib-http-util:0.18.0" level="project" />
+    <orderEntry type="library" name="Python 3.6 interpreter library" level="application" />
   </component>
 </module>


### PR DESCRIPTION
This is a simple tool intended for quickstart usecases. Given only a list of kafka servers to connect to and a connector config file, it handles downloading, installing and running a standalone connector instance.