### PR TITLE
feat: Implement Streaming pull CloudPubSubSubscriber

### DIFF
--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -7,9 +7,9 @@
   <name>Archetype - kafka-connector</name>
   <url>http://maven.apache.org</url>
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
-</properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.108.3</version>
+      <version>1.112.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubGRPCSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubGRPCSubscriber.java
@@ -16,16 +16,23 @@
 package com.google.pubsub.kafka.source;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Empty;
 import com.google.pubsub.kafka.common.ConnectorUtils;
 import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,46 +46,66 @@ public class CloudPubSubGRPCSubscriber implements CloudPubSubSubscriber {
   private static final Logger log = LoggerFactory.getLogger(CloudPubSubGRPCSubscriber.class);
   private long nextSubscriberResetTime = 0;
   private GrpcSubscriberStub subscriber;
-  private Random rand = new Random(System.currentTimeMillis());
-  private CredentialsProvider gcpCredentialsProvider;
-  private String endpoint;
+  private final CredentialsProvider gcpCredentialsProvider;
+  private final String endpoint;
+  private final ProjectSubscriptionName subscriptionName;
+  private final int cpsMaxBatchSize;
 
-  CloudPubSubGRPCSubscriber(CredentialsProvider gcpCredentialsProvider, String endpoint) {
+  CloudPubSubGRPCSubscriber(CredentialsProvider gcpCredentialsProvider, String endpoint,
+      ProjectSubscriptionName subscriptionName, int cpsMaxBatchSize) {
     this.gcpCredentialsProvider = gcpCredentialsProvider;
     this.endpoint = endpoint;
+    this.subscriptionName = subscriptionName;
+    this.cpsMaxBatchSize = cpsMaxBatchSize;
     makeSubscriber();
   }
 
-  public ApiFuture<PullResponse> pull(PullRequest request) {
+  @Override
+  public ApiFuture<List<ReceivedMessage>> pull() {
     if (System.currentTimeMillis() > nextSubscriberResetTime) {
       makeSubscriber();
     }
-    return subscriber.pullCallable().futureCall(request);
+    return ApiFutures.transform(subscriber.pullCallable().futureCall(
+        PullRequest.newBuilder().setSubscription(subscriptionName.toString())
+            .setMaxMessages(cpsMaxBatchSize).build()), PullResponse::getReceivedMessagesList,
+        MoreExecutors.directExecutor());
   }
 
-  public ApiFuture<Empty> ackMessages(AcknowledgeRequest request) {
+  @Override
+  public ApiFuture<Empty> ackMessages(Collection<String> ackIds) {
     if (System.currentTimeMillis() > nextSubscriberResetTime) {
       makeSubscriber();
     }
-    return subscriber.acknowledgeCallable().futureCall(request);
+    return subscriber.acknowledgeCallable().futureCall(
+        AcknowledgeRequest.newBuilder().setSubscription(subscriptionName.toString())
+            .addAllAckIds(ackIds).build());
+  }
+
+  @Override
+  public void close() {
+    subscriber.close();
   }
 
   private void makeSubscriber() {
     try {
+      if (subscriber != null) {
+        subscriber.close();
+      }
       log.info("Creating subscriber.");
       SubscriberStubSettings subscriberStubSettings =
-      SubscriberStubSettings.newBuilder()
-        .setTransportChannelProvider(
-            SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
-                .setMaxInboundMessageSize(20 << 20) // 20MB
-                .build())
-        .setCredentialsProvider(gcpCredentialsProvider)
-        .setEndpoint(endpoint)
-        .build();
+          SubscriberStubSettings.newBuilder()
+              .setTransportChannelProvider(
+                  SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
+                      .setMaxInboundMessageSize(20 << 20) // 20MB
+                      .build())
+              .setCredentialsProvider(gcpCredentialsProvider)
+              .setEndpoint(endpoint)
+              .build();
       subscriber = GrpcSubscriberStub.create(subscriberStubSettings);
       // We change the subscriber every 25 - 35 minutes in order to avoid GOAWAY errors.
       nextSubscriberResetTime =
-          System.currentTimeMillis() + rand.nextInt(10 * 60 * 1000) + 25 * 60 * 1000;
+          System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(10 * 60 * 1000)
+              + 25 * 60 * 1000;
     } catch (IOException e) {
       throw new RuntimeException("Could not create subscriber stub; no subscribing can occur.", e);
     }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubRoundRobinSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubRoundRobinSubscriber.java
@@ -18,10 +18,10 @@ package com.google.pubsub.kafka.source;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.protobuf.Empty;
-import com.google.pubsub.v1.AcknowledgeRequest;
-import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ReceivedMessage;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,25 +30,36 @@ import java.util.List;
  */
 public class CloudPubSubRoundRobinSubscriber implements CloudPubSubSubscriber {
 
-  private List<CloudPubSubSubscriber> subscribers;
+  private final List<CloudPubSubSubscriber> subscribers;
   private int currentSubscriberIndex = 0;
 
-  public CloudPubSubRoundRobinSubscriber(int subscriberCount, CredentialsProvider gcpCredentialsProvider, String endpoint) {
+  public CloudPubSubRoundRobinSubscriber(int subscriberCount,
+      CredentialsProvider gcpCredentialsProvider, String endpoint,
+      ProjectSubscriptionName subscriptionName, int cpsMaxBatchSize) {
     subscribers = new ArrayList<>();
     for (int i = 0; i < subscriberCount; ++i) {
-      subscribers.add(new CloudPubSubGRPCSubscriber(gcpCredentialsProvider, endpoint));
+      subscribers.add(
+          new CloudPubSubGRPCSubscriber(gcpCredentialsProvider, endpoint, subscriptionName,
+              cpsMaxBatchSize));
     }
   }
 
   @Override
-  public ApiFuture<PullResponse> pull(PullRequest request) {
-    currentSubscriberIndex = (currentSubscriberIndex + 1) % subscribers.size();
-    return subscribers.get(currentSubscriberIndex).pull(request);
+  public void close() {
+    for (CloudPubSubSubscriber subscriber : subscribers) {
+      subscriber.close();
+    }
   }
 
   @Override
-  public ApiFuture<Empty> ackMessages(AcknowledgeRequest request) {
+  public ApiFuture<List<ReceivedMessage>> pull() {
     currentSubscriberIndex = (currentSubscriberIndex + 1) % subscribers.size();
-    return subscribers.get(currentSubscriberIndex).ackMessages(request);
+    return subscribers.get(currentSubscriberIndex).pull();
+  }
+
+  @Override
+  public ApiFuture<Empty> ackMessages(Collection<String> ackIds) {
+    currentSubscriberIndex = (currentSubscriberIndex + 1) % subscribers.size();
+    return subscribers.get(currentSubscriberIndex).ackMessages(ackIds);
   }
 }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -57,6 +57,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public static final String CPS_SUBSCRIPTION_CONFIG = "cps.subscription";
   public static final String CPS_MAX_BATCH_SIZE_CONFIG = "cps.maxBatchSize";
   public static final String CPS_STREAMING_PULL_ENABLED = "cps.streamingPull.enabled";
+  public static final String CPS_STREAMING_PULL_PARALLEL_PULL_COUNT = "cps.streamingPull.parallelPullCount";
   public static final String CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES = "cps.streamingPull.flowControlMessages";
   public static final String CPS_STREAMING_PULL_FLOW_CONTROL_BYTES = "cps.streamingPull.flowControlBytes";
   public static final int DEFAULT_CPS_MAX_BATCH_SIZE = 100;
@@ -203,6 +204,12 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             false,
             Importance.MEDIUM,
             "Whether to use streaming pull for the connector to connect to Cloud Pub/Sub. If provided, cps.maxBatchSize is ignored.")
+        .define(
+            CPS_STREAMING_PULL_PARALLEL_PULL_COUNT,
+            Type.INT,
+            10,
+            Importance.MEDIUM,
+            "The number of streams to open per task when using streaming pull, defaults to 10.")
         .define(
             CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES,
             Type.LONG,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -57,7 +57,6 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public static final String CPS_SUBSCRIPTION_CONFIG = "cps.subscription";
   public static final String CPS_MAX_BATCH_SIZE_CONFIG = "cps.maxBatchSize";
   public static final String CPS_STREAMING_PULL_ENABLED = "cps.streamingPull.enabled";
-  public static final String CPS_STREAMING_PULL_PARALLEL_PULL_COUNT = "cps.streamingPull.parallelPullCount";
   public static final String CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES = "cps.streamingPull.flowControlMessages";
   public static final String CPS_STREAMING_PULL_FLOW_CONTROL_BYTES = "cps.streamingPull.flowControlBytes";
   public static final int DEFAULT_CPS_MAX_BATCH_SIZE = 100;
@@ -204,12 +203,6 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             false,
             Importance.MEDIUM,
             "Whether to use streaming pull for the connector to connect to Cloud Pub/Sub. If provided, cps.maxBatchSize is ignored.")
-        .define(
-            CPS_STREAMING_PULL_PARALLEL_PULL_COUNT,
-            Type.INT,
-            10,
-            Importance.MEDIUM,
-            "The number of streams to open per task when using streaming pull, defaults to 10.")
         .define(
             CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES,
             Type.LONG,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -16,6 +16,7 @@
 package com.google.pubsub.kafka.source;
 
 import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.common.annotations.VisibleForTesting;
@@ -55,6 +56,9 @@ public class CloudPubSubSourceConnector extends SourceConnector {
   public static final String CPS_MAKE_ORDERING_KEY_ATTRIBUTE = "cps.makeOrderingKeyAttribute";
   public static final String CPS_SUBSCRIPTION_CONFIG = "cps.subscription";
   public static final String CPS_MAX_BATCH_SIZE_CONFIG = "cps.maxBatchSize";
+  public static final String CPS_STREAMING_PULL_ENABLED = "cps.streamingPull.enabled";
+  public static final String CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES = "cps.streamingPull.flowControlMessages";
+  public static final String CPS_STREAMING_PULL_FLOW_CONTROL_BYTES = "cps.streamingPull.flowControlBytes";
   public static final int DEFAULT_CPS_MAX_BATCH_SIZE = 100;
   public static final int DEFAULT_KAFKA_PARTITIONS = 1;
   public static final String DEFAULT_KAFKA_PARTITION_SCHEME = "round_robin";
@@ -193,6 +197,24 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             ConfigDef.Range.between(1, Integer.MAX_VALUE),
             Importance.MEDIUM,
             "The maximum number of messages to batch per pull request to Cloud Pub/Sub.")
+        .define(
+            CPS_STREAMING_PULL_ENABLED,
+            Type.BOOLEAN,
+            false,
+            Importance.MEDIUM,
+            "Whether to use streaming pull for the connector to connect to Cloud Pub/Sub. If provided, cps.maxBatchSize is ignored.")
+        .define(
+            CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES,
+            Type.LONG,
+            1000L,
+            Importance.MEDIUM,
+            "The maximum number of outstanding messages per task when using streaming pull.")
+        .define(
+            CPS_STREAMING_PULL_FLOW_CONTROL_BYTES,
+            Type.LONG,
+            100L * 1024 * 1024,
+            Importance.MEDIUM,
+            "The maximum number of outstanding message bytes per task when using streaming pull.")
         .define(
             KAFKA_MESSAGE_KEY_CONFIG,
             Type.STRING,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -16,6 +16,9 @@
 package com.google.pubsub.kafka.source;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
+import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
@@ -23,10 +26,8 @@ import com.google.protobuf.util.Timestamps;
 import com.google.pubsub.kafka.common.ConnectorUtils;
 import com.google.pubsub.kafka.common.ConnectorCredentialsProvider;
 import com.google.pubsub.kafka.source.CloudPubSubSourceConnector.PartitionScheme;
-import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -43,7 +44,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.ConnectHeaders;
-import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
@@ -60,25 +60,22 @@ public class CloudPubSubSourceTask extends SourceTask {
   private static final int NUM_CPS_SUBSCRIBERS = 10;
 
   private String kafkaTopic;
-  private String cpsSubscription;
-  private String cpsEndpoint;
+  private ProjectSubscriptionName cpsSubscription;
   private String kafkaMessageKeyAttribute;
   private String kafkaMessageTimestampAttribute;
   private boolean makeOrderingKeyAttribute;
   private int kafkaPartitions;
   private PartitionScheme kafkaPartitionScheme;
-  private int cpsMaxBatchSize;
   // Keeps track of the current partition to publish to if the partition scheme is round robin.
   private int currentRoundRobinPartition = -1;
   // Keep track of all ack ids that have not been sent correctly acked yet.
   private final Set<String> deliveredAckIds = Collections.synchronizedSet(new HashSet<String>());
-  private Set<String> ackIds = Collections.synchronizedSet(new HashSet<String>());
+  private final Set<String> ackIds = Collections.synchronizedSet(new HashSet<String>());
   private CloudPubSubSubscriber subscriber;
-  private Set<String> ackIdsInFlight = Collections.synchronizedSet(new HashSet<String>());
+  private final Set<String> ackIdsInFlight = Collections.synchronizedSet(new HashSet<String>());
   private final Set<String> standardAttributes = new HashSet<>();
-  private ConnectorCredentialsProvider gcpCredentialsProvider;
   private boolean useKafkaHeaders;
-  private Executor ackExecutor = Executors.newCachedThreadPool();
+  private final Executor ackExecutor = Executors.newCachedThreadPool();
 
   public CloudPubSubSourceTask() {}
 
@@ -95,15 +92,15 @@ public class CloudPubSubSourceTask extends SourceTask {
   @Override
   public void start(Map<String, String> props) {
     Map<String, Object> validatedProps = new CloudPubSubSourceConnector().config().parse(props);
-    cpsSubscription =
-        String.format(
-            ConnectorUtils.CPS_SUBSCRIPTION_FORMAT,
-            validatedProps.get(ConnectorUtils.CPS_PROJECT_CONFIG).toString(),
-            validatedProps.get(CloudPubSubSourceConnector.CPS_SUBSCRIPTION_CONFIG).toString());
-    cpsEndpoint = (String) validatedProps.get(ConnectorUtils.CPS_ENDPOINT);
+    cpsSubscription = ProjectSubscriptionName.newBuilder()
+        .setProject(validatedProps.get(ConnectorUtils.CPS_PROJECT_CONFIG).toString())
+        .setSubscription(
+            validatedProps.get(CloudPubSubSourceConnector.CPS_SUBSCRIPTION_CONFIG).toString())
+        .build();
+    String cpsEndpoint = (String) validatedProps.get(ConnectorUtils.CPS_ENDPOINT);
     kafkaTopic = validatedProps.get(CloudPubSubSourceConnector.KAFKA_TOPIC_CONFIG).toString();
-    cpsMaxBatchSize =
-        (Integer) validatedProps.get(CloudPubSubSourceConnector.CPS_MAX_BATCH_SIZE_CONFIG);
+    int cpsMaxBatchSize = (Integer) validatedProps
+        .get(CloudPubSubSourceConnector.CPS_MAX_BATCH_SIZE_CONFIG);
     kafkaPartitions =
         (Integer) validatedProps.get(CloudPubSubSourceConnector.KAFKA_PARTITIONS_CONFIG);
     kafkaMessageKeyAttribute =
@@ -116,9 +113,17 @@ public class CloudPubSubSourceTask extends SourceTask {
     useKafkaHeaders = (Boolean) validatedProps.get(CloudPubSubSourceConnector.USE_KAFKA_HEADERS);
     makeOrderingKeyAttribute =
         (Boolean) validatedProps.get(CloudPubSubSourceConnector.CPS_MAKE_ORDERING_KEY_ATTRIBUTE);
-    gcpCredentialsProvider = new ConnectorCredentialsProvider();
-    String gcpCredentialsFilePath = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
-    String credentialsJson = (String) validatedProps.get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
+    ConnectorCredentialsProvider gcpCredentialsProvider = new ConnectorCredentialsProvider();
+    String gcpCredentialsFilePath = (String) validatedProps
+        .get(ConnectorUtils.GCP_CREDENTIALS_FILE_PATH_CONFIG);
+    String credentialsJson = (String) validatedProps
+        .get(ConnectorUtils.GCP_CREDENTIALS_JSON_CONFIG);
+    boolean useStreamingPull = (Boolean) validatedProps
+        .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_ENABLED);
+    long streamingPullBytes = (Long) validatedProps
+        .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_BYTES);
+    long streamingPullMessages = (Long) validatedProps
+        .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES);
     if (gcpCredentialsFilePath != null) {
       try {
         gcpCredentialsProvider.loadFromFile(gcpCredentialsFilePath);
@@ -132,9 +137,24 @@ public class CloudPubSubSourceTask extends SourceTask {
         throw new RuntimeException(e);
       }
     }
+    // Only do this if we did not set through the constructor.
     if (subscriber == null) {
-      // Only do this if we did not set through the constructor.
-      subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS, gcpCredentialsProvider, cpsEndpoint);
+      if (useStreamingPull) {
+        subscriber = new StreamingPullSubscriber(
+            receiver -> Subscriber.newBuilder(cpsSubscription, receiver)
+                .setCredentialsProvider(gcpCredentialsProvider)
+                .setFlowControlSettings(
+                    FlowControlSettings.newBuilder()
+                        .setLimitExceededBehavior(LimitExceededBehavior.Block)
+                        .setMaxOutstandingElementCount(streamingPullMessages)
+                        .setMaxOutstandingRequestBytes(streamingPullBytes).build())
+                .setEndpoint(cpsEndpoint)
+                .build());
+      } else {
+        subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS,
+            gcpCredentialsProvider,
+            cpsEndpoint, cpsSubscription, cpsMaxBatchSize);
+      }
     }
     standardAttributes.add(kafkaMessageKeyAttribute);
     standardAttributes.add(kafkaMessageTimestampAttribute);
@@ -145,23 +165,18 @@ public class CloudPubSubSourceTask extends SourceTask {
   public List<SourceRecord> poll() throws InterruptedException {
     ackMessages();
     log.debug("Polling...");
-    PullRequest request =
-        PullRequest.newBuilder()
-            .setSubscription(cpsSubscription)
-            .setReturnImmediately(false)
-            .setMaxMessages(cpsMaxBatchSize)
-            .build();
     try {
-      PullResponse response = subscriber.pull(request).get();
+      List<ReceivedMessage> response = subscriber.pull().get();
       List<SourceRecord> sourceRecords = new ArrayList<>();
-      log.trace("Received " + response.getReceivedMessagesList().size() + " messages");
-      for (ReceivedMessage rm : response.getReceivedMessagesList()) {
+      log.trace("Received " + response.size() + " messages");
+      for (ReceivedMessage rm : response) {
         PubsubMessage message = rm.getMessage();
         String ackId = rm.getAckId();
         // If we are receiving this message a second (or more) times because the ack for it failed
         // then do not create a SourceRecord for this message. In case we are waiting for ack
         // response we also skip the message
-        if (ackIds.contains(ackId) || deliveredAckIds.contains(ackId) || ackIdsInFlight.contains(ackId)) {
+        if (ackIds.contains(ackId) || deliveredAckIds.contains(ackId) || ackIdsInFlight
+            .contains(ackId)) {
           continue;
         }
         ackIds.add(ackId);
@@ -183,7 +198,7 @@ public class CloudPubSubSourceTask extends SourceTask {
         boolean hasCustomAttributes = !standardAttributes.containsAll(messageAttributes.keySet())
             || (makeOrderingKeyAttribute && orderingKey != null && !orderingKey.isEmpty());
 
-        Map<String,String> ack = Collections.singletonMap(cpsSubscription, ackId);
+        Map<String, String> ack = Collections.singletonMap(cpsSubscription.toString(), ackId);
         SourceRecord record = null;
         if (hasCustomAttributes) {
           if (useKafkaHeaders) {
@@ -305,28 +320,22 @@ public class CloudPubSubSourceTask extends SourceTask {
    */
   private void ackMessages() {
     if (deliveredAckIds.size() != 0) {
-      AcknowledgeRequest.Builder requestBuilder = AcknowledgeRequest.newBuilder()
-          .setSubscription(cpsSubscription);
       final Set<String> ackIdsBatch = new HashSet<>();
       synchronized (deliveredAckIds) {
-        requestBuilder.addAllAckIds(deliveredAckIds);
         ackIdsInFlight.addAll(deliveredAckIds);
         ackIdsBatch.addAll(deliveredAckIds);
         deliveredAckIds.clear();
       }
-      final ApiFuture<Empty> response = subscriber.ackMessages(requestBuilder.build());
-      response.addListener(new Runnable() {
-        @Override
-        public void run() {
-          try {
-            response.get();
-            log.trace("Successfully acked a set of messages. {}", ackIdsBatch.size());
-          } catch (Exception e) {
-            deliveredAckIds.addAll(ackIdsBatch);
-            log.error("An exception occurred acking messages: " + e);
-          } finally {
-            ackIdsInFlight.removeAll(ackIdsBatch);
-          }
+      final ApiFuture<Empty> response = subscriber.ackMessages(ackIdsBatch);
+      response.addListener(() -> {
+        try {
+          response.get();
+          log.trace("Successfully acked a set of messages. {}", ackIdsBatch.size());
+        } catch (Exception e) {
+          deliveredAckIds.addAll(ackIdsBatch);
+          log.error("An exception occurred acking messages: " + e);
+        } finally {
+          ackIdsInFlight.removeAll(ackIdsBatch);
         }
       }, ackExecutor);
     }
@@ -362,11 +371,15 @@ public class CloudPubSubSourceTask extends SourceTask {
   }
 
   @Override
-  public void stop() {}
+  public void stop() {
+    if (subscriber != null) {
+      subscriber.close();
+    }
+  }
 
   @Override
   public void commitRecord(SourceRecord record) {
-    String ackId = record.sourceOffset().get(cpsSubscription).toString();
+    String ackId = record.sourceOffset().get(cpsSubscription.toString()).toString();
     deliveredAckIds.add(ackId);
     ackIds.remove(ackId);
     log.trace("Committed {}", ackId);

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -124,6 +124,8 @@ public class CloudPubSubSourceTask extends SourceTask {
         .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_BYTES);
     long streamingPullMessages = (Long) validatedProps
         .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES);
+    int streamingPullParallelPullCount = (Integer) validatedProps.get(
+        CloudPubSubSourceConnector.CPS_STREAMING_PULL_PARALLEL_PULL_COUNT);
     if (gcpCredentialsFilePath != null) {
       try {
         gcpCredentialsProvider.loadFromFile(gcpCredentialsFilePath);
@@ -149,6 +151,7 @@ public class CloudPubSubSourceTask extends SourceTask {
                         .setMaxOutstandingElementCount(streamingPullMessages)
                         .setMaxOutstandingRequestBytes(streamingPullBytes).build())
                 .setEndpoint(cpsEndpoint)
+                .setParallelPullCount(streamingPullParallelPullCount)
                 .build());
       } else {
         subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -125,8 +125,6 @@ public class CloudPubSubSourceTask extends SourceTask {
         .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_BYTES);
     long streamingPullMessages = (Long) validatedProps
         .get(CloudPubSubSourceConnector.CPS_STREAMING_PULL_FLOW_CONTROL_MESSAGES);
-    int streamingPullParallelPullCount = (Integer) validatedProps.get(
-        CloudPubSubSourceConnector.CPS_STREAMING_PULL_PARALLEL_PULL_COUNT);
     if (gcpCredentialsFilePath != null) {
       try {
         gcpCredentialsProvider.loadFromFile(gcpCredentialsFilePath);
@@ -152,7 +150,6 @@ public class CloudPubSubSourceTask extends SourceTask {
                         .setMaxOutstandingElementCount(streamingPullMessages)
                         .setMaxOutstandingRequestBytes(streamingPullBytes).build())
                 .setEndpoint(cpsEndpoint)
-                .setParallelPullCount(streamingPullParallelPullCount)
                 .build());
       } else {
         subscriber = new CloudPubSubRoundRobinSubscriber(NUM_CPS_SUBSCRIBERS,

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSubscriber.java
@@ -17,17 +17,18 @@ package com.google.pubsub.kafka.source;
 
 import com.google.api.core.ApiFuture;
 import com.google.protobuf.Empty;
-import com.google.pubsub.v1.AcknowledgeRequest;
-import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * An interface for clients that want to subscribe to messages from to <a
  * href="https://cloud.google.com/pubsub">Google Cloud Pub/Sub</a>.
  */
-public interface CloudPubSubSubscriber {
+public interface CloudPubSubSubscriber extends AutoCloseable {
+  ApiFuture<List<ReceivedMessage>> pull();
 
-  public ApiFuture<PullResponse> pull(PullRequest request);
+  ApiFuture<Empty> ackMessages(Collection<String> ackIds);
 
-  public ApiFuture<Empty> ackMessages(AcknowledgeRequest request);
+  void close();
 }

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriber.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriber.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.pubsub.kafka.source;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.ApiService.Listener;
+import com.google.api.core.ApiService.State;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.SubscriberInterface;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import com.google.protobuf.Empty;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+public class StreamingPullSubscriber implements CloudPubSubSubscriber {
+
+  private final SubscriberInterface underlying;
+
+  @GuardedBy("this")
+  private Optional<ApiException> error = Optional.empty();
+
+  @GuardedBy("this")
+  private final Deque<ReceivedMessage> messages = new ArrayDeque<>();
+
+  @GuardedBy("this")
+  private long nextId = 0;
+
+  @GuardedBy("this")
+  private final Map<String, AckReplyConsumer> ackConsumers = new HashMap<>();
+
+  @GuardedBy("this")
+  private Optional<SettableApiFuture<Void>> notification = Optional.empty();
+
+  public StreamingPullSubscriber(StreamingPullSubscriberFactory factory) throws ApiException {
+    underlying = factory.newSubscriber(this::addMessage);
+    underlying.addListener(
+        new Listener() {
+          @Override
+          public void failed(State state, Throwable throwable) {
+            fail(toApiException(throwable));
+          }
+        },
+        MoreExecutors.directExecutor());
+    underlying.startAsync().awaitRunning();
+  }
+
+  private static ApiException toApiException(Throwable t) {
+    try {
+      throw t;
+    } catch (ApiException e) {
+      return e;
+    } catch (ExecutionException e) {
+      return toApiException(e.getCause());
+    } catch (Throwable t2) {
+      return new ApiException(t2, new StatusCode() {
+        @Override
+        public Code getCode() {
+          return Code.INTERNAL;
+        }
+
+        @Override
+        public Object getTransportCode() {
+          return null;
+        }
+      }, false);
+    }
+  }
+
+  private synchronized void fail(ApiException e) {
+    error = Optional.of(e);
+    if (notification.isPresent()) {
+      notification.get().setException(e);
+      notification = Optional.empty();
+    }
+  }
+
+  private synchronized void addMessage(PubsubMessage message, AckReplyConsumer consumer) {
+    String ackId = Long.toString(nextId++);
+    messages.add(ReceivedMessage.newBuilder().setMessage(message).setAckId(ackId).build());
+    ackConsumers.put(ackId, consumer);
+    if (notification.isPresent()) {
+      notification.get().set(null);
+      notification = Optional.empty();
+    }
+  }
+
+  private synchronized ApiFuture<Void> onData() {
+    if (error.isPresent()) {
+      return ApiFutures.immediateFailedFuture(error.get());
+    }
+    if (!messages.isEmpty()) {
+      return ApiFutures.immediateFuture(null);
+    }
+    if (!notification.isPresent()) {
+      notification = Optional.of(SettableApiFuture.create());
+    }
+    return notification.get();
+  }
+
+  private synchronized List<ReceivedMessage> takeMessages() {
+    List<ReceivedMessage> toReturn = ImmutableList.copyOf(messages);
+    messages.clear();
+    return toReturn;
+  }
+
+  @Override
+  public void close() {
+    synchronized (this) {
+      if (!error.isPresent()) {
+        error = Optional.of(toApiException(new Throwable("Subscriber client shut down")));
+      }
+    }
+    underlying.stopAsync().awaitTerminated();
+  }
+
+  @Override
+  public synchronized ApiFuture<List<ReceivedMessage>> pull() {
+    SettableApiFuture<List<ReceivedMessage>> toReturn = SettableApiFuture.create();
+    ApiFutures.addCallback(onData(), new ApiFutureCallback<Void>() {
+      @Override
+      public void onFailure(Throwable t) {
+        toReturn.setException(toApiException(t));
+      }
+
+      @Override
+      public void onSuccess(Void result) {
+        toReturn.set(takeMessages());
+      }
+    }, MoreExecutors.directExecutor());
+    return toReturn;
+  }
+
+  @Override
+  public synchronized ApiFuture<Empty> ackMessages(Collection<String> ackIds) {
+    ackIds.forEach(
+        id -> Optional.ofNullable(ackConsumers.remove(id)).ifPresent(AckReplyConsumer::ack));
+    return ApiFutures.immediateFuture(null);
+  }
+}

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberFactory.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberFactory.java
@@ -1,0 +1,8 @@
+package com.google.pubsub.kafka.source;
+
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.SubscriberInterface;
+
+public interface StreamingPullSubscriberFactory {
+  SubscriberInterface newSubscriber(MessageReceiver receiver);
+}

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberImpl.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberImpl.java
@@ -1,5 +1,0 @@
-package com.google.pubsub.kafka.source;
-
-public class StreamingPullSubscriberImpl {
-
-}

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberImpl.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/source/StreamingPullSubscriberImpl.java
@@ -1,0 +1,5 @@
+package com.google.pubsub.kafka.source;
+
+public class StreamingPullSubscriberImpl {
+
+}

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -26,15 +26,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.pubsub.kafka.common.ConnectorUtils;
-import com.google.pubsub.v1.AcknowledgeRequest;
 import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.PullRequest;
-import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
 import java.util.HashMap;
 import java.util.List;
@@ -121,10 +118,9 @@ public class CloudPubSubSourceTaskTest {
   @Test
   public void testPollCaseWithNoMessages() throws Exception {
     task.start(props);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of());
     assertEquals(0, task.poll().size());
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
   }
 
   /**
@@ -135,22 +131,20 @@ public class CloudPubSubSourceTaskTest {
   public void testPollInRegularCase() throws Exception {
     task.start(props);
     ReceivedMessage rm1 =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm1).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1));
     List<SourceRecord> result = task.poll();
     assertEquals(1, result.size());
     task.commitRecord(result.get(0));
-    stubbedPullResponse = PullResponse.newBuilder().build();
     SettableApiFuture<Empty> goodFuture = SettableApiFuture.create();
     goodFuture.set(Empty.getDefaultInstance());
-    when(subscriber.ackMessages(any(AcknowledgeRequest.class))).thenReturn(goodFuture);
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.ackMessages(any())).thenReturn(goodFuture);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of());
     result = task.poll();
     assertEquals(0, result.size());
     result = task.poll();
     assertEquals(0, result.size());
-    verify(subscriber, times(1)).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, times(1)).ackMessages(any());
   }
 
 
@@ -163,16 +157,13 @@ public class CloudPubSubSourceTaskTest {
   public void testPollWithDuplicateReceivedMessages() throws Exception {
     task.start(props);
     ReceivedMessage rm1 =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm1).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1));
     List<SourceRecord> result = task.poll();
     assertEquals(1, result.size());
     ReceivedMessage rm2 =
-        createReceivedMessage(ACK_ID2, CPS_MESSAGE, new HashMap<String, String>(), null);
-    stubbedPullResponse =
-        PullResponse.newBuilder().addReceivedMessages(0, rm1).addReceivedMessages(1, rm2).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID2, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1, rm2));
     result = task.poll();
     assertEquals(1, result.size());
   }
@@ -185,11 +176,10 @@ public class CloudPubSubSourceTaskTest {
   public void testPollWithNoMessageKeyAttribute() throws Exception {
     task.start(props);
     ReceivedMessage rm =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
         new SourceRecord(
@@ -214,10 +204,9 @@ public class CloudPubSubSourceTaskTest {
     Map<String, String> attributes = new HashMap<>();
     attributes.put(KAFKA_MESSAGE_KEY_ATTRIBUTE, KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE);
     ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, attributes, null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
         new SourceRecord(
@@ -243,10 +232,9 @@ public class CloudPubSubSourceTaskTest {
     attributes.put(KAFKA_MESSAGE_KEY_ATTRIBUTE, KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE);
     attributes.put(KAFKA_MESSAGE_TIMESTAMP_ATTRIBUTE, KAFKA_MESSAGE_TIMESTAMP_ATTRIBUTE_VALUE);
     ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, attributes, null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
             new SourceRecord(
@@ -274,10 +262,9 @@ public class CloudPubSubSourceTaskTest {
     attributes.put("attribute1", "attribute_value1");
     attributes.put("attribute2", "attribute_value2");
     ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, attributes, null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
 
     ConnectHeaders headers = new ConnectHeaders();
@@ -307,11 +294,10 @@ public class CloudPubSubSourceTaskTest {
     props.put(CloudPubSubSourceConnector.CPS_MAKE_ORDERING_KEY_ATTRIBUTE, "true");
     task.start(props);
     ReceivedMessage rm =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), "my-key");
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), "my-key");
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
 
     Schema expectedSchema =
@@ -346,11 +332,10 @@ public class CloudPubSubSourceTaskTest {
     props.put(CloudPubSubSourceConnector.CPS_MAKE_ORDERING_KEY_ATTRIBUTE, "true");
     task.start(props);
     ReceivedMessage rm =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), "my-key");
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), "my-key");
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
 
     ConnectHeaders headers = new ConnectHeaders();
@@ -383,10 +368,9 @@ public class CloudPubSubSourceTaskTest {
     attributes.put("attribute1", "attribute_value1");
     attributes.put("attribute2", "attribute_value2");
     ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, attributes, null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     Schema expectedSchema =
         SchemaBuilder.struct()
@@ -424,16 +408,11 @@ public class CloudPubSubSourceTaskTest {
     Map<String, String> attributes = new HashMap<>();
     attributes.put(KAFKA_MESSAGE_KEY_ATTRIBUTE, KAFKA_MESSAGE_KEY_ATTRIBUTE_VALUE);
     ReceivedMessage withoutKey =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
     ReceivedMessage withKey = createReceivedMessage(ACK_ID2, CPS_MESSAGE, attributes, null);
-    PullResponse stubbedPullResponse =
-        PullResponse.newBuilder()
-            .addReceivedMessages(0, withKey)
-            .addReceivedMessages(1, withoutKey)
-            .build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(withKey, withoutKey));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(2, result.size());
     SourceRecord expectedForMessageWithKey =
         new SourceRecord(
@@ -468,11 +447,10 @@ public class CloudPubSubSourceTaskTest {
         CloudPubSubSourceConnector.PartitionScheme.HASH_VALUE.toString());
     task.start(props);
     ReceivedMessage rm =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
         new SourceRecord(
@@ -494,11 +472,10 @@ public class CloudPubSubSourceTaskTest {
             CloudPubSubSourceConnector.KAFKA_PARTITION_SCHEME_CONFIG,
             CloudPubSubSourceConnector.PartitionScheme.KAFKA_PARTITIONER.toString());
     task.start(props);
-    ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
             new SourceRecord(
@@ -523,11 +500,10 @@ public class CloudPubSubSourceTaskTest {
         CloudPubSubSourceConnector.PartitionScheme.ORDERING_KEY.toString());
     task.start(props);
     ReceivedMessage rm =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), orderingKey);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), orderingKey);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
     SourceRecord expected =
         new SourceRecord(
@@ -551,23 +527,16 @@ public class CloudPubSubSourceTaskTest {
   public void testPollWithPartitionSchemeRoundRobin() throws Exception {
     task.start(props);
     ReceivedMessage rm1 =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<String, String>(), null);
+        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
     ReceivedMessage rm2 =
-        createReceivedMessage(ACK_ID2, CPS_MESSAGE, new HashMap<String, String>(), null);
+        createReceivedMessage(ACK_ID2, CPS_MESSAGE, new HashMap<>(), null);
     ReceivedMessage rm3 =
-        createReceivedMessage(ACK_ID3, CPS_MESSAGE, new HashMap<String, String>(), null);
+        createReceivedMessage(ACK_ID3, CPS_MESSAGE, new HashMap<>(), null);
     ReceivedMessage rm4 =
-        createReceivedMessage(ACK_ID4, CPS_MESSAGE, new HashMap<String, String>(), null);
-    PullResponse stubbedPullResponse =
-        PullResponse.newBuilder()
-            .addReceivedMessages(0, rm1)
-            .addReceivedMessages(1, rm2)
-            .addReceivedMessages(2, rm3)
-            .addReceivedMessages(3, rm4)
-            .build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+        createReceivedMessage(ACK_ID4, CPS_MESSAGE, new HashMap<>(), null);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1, rm2, rm3, rm4));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(4, result.size());
     SourceRecord expected1 =
         new SourceRecord(
@@ -626,10 +595,9 @@ public class CloudPubSubSourceTaskTest {
     task.start(props);
     Map<String, String> attributes = new HashMap<>();
     ReceivedMessage rm = createReceivedMessage(ACK_ID1, CPS_MESSAGE, attributes, orderingKey);
-    PullResponse stubbedPullResponse = PullResponse.newBuilder().addReceivedMessages(rm).build();
-    when(subscriber.pull(any(PullRequest.class)).get()).thenReturn(stubbedPullResponse);
+    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm));
     List<SourceRecord> result = task.poll();
-    verify(subscriber, never()).ackMessages(any(AcknowledgeRequest.class));
+    verify(subscriber, never()).ackMessages(any());
     assertEquals(1, result.size());
 
     SourceRecord expected =
@@ -649,7 +617,7 @@ public class CloudPubSubSourceTaskTest {
   public void testPollExceptionCase() throws Exception {
     task.start(props);
     // Could also throw ExecutionException if we wanted to...
-    when(subscriber.pull(any(PullRequest.class)).get()).thenThrow(new InterruptedException());
+    when(subscriber.pull().get()).thenThrow(new InterruptedException());
     assertEquals(0, task.poll().size());
   }
 

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/CloudPubSubSourceTaskTest.java
@@ -147,27 +147,6 @@ public class CloudPubSubSourceTaskTest {
     verify(subscriber, times(1)).ackMessages(any());
   }
 
-
-  /**
-   * Tests that when a call to ackMessages() fails, that the message is not redelivered to Kafka if
-   * the message is received again by Cloud Pub/Sub. Also tests that ack ids are added properly if
-   * the ack id has not been seen before.
-   */
-  @Test
-  public void testPollWithDuplicateReceivedMessages() throws Exception {
-    task.start(props);
-    ReceivedMessage rm1 =
-        createReceivedMessage(ACK_ID1, CPS_MESSAGE, new HashMap<>(), null);
-    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1));
-    List<SourceRecord> result = task.poll();
-    assertEquals(1, result.size());
-    ReceivedMessage rm2 =
-        createReceivedMessage(ACK_ID2, CPS_MESSAGE, new HashMap<>(), null);
-    when(subscriber.pull().get()).thenReturn(ImmutableList.of(rm1, rm2));
-    result = task.poll();
-    assertEquals(1, result.size());
-  }
-
   /**
    * Tests when the message(s) retrieved from Cloud Pub/Sub do not have an attribute that matches
    * {@link #KAFKA_MESSAGE_KEY_ATTRIBUTE}.

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/source/StreamingPullSubscriberTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/source/StreamingPullSubscriberTest.java
@@ -1,0 +1,184 @@
+package com.google.pubsub.kafka.source;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiService;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.SubscriberInterface;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+
+public class StreamingPullSubscriberTest {
+  private final StreamingPullSubscriberFactory underlyingFactory = mock(StreamingPullSubscriberFactory.class);
+  private final SubscriberInterface underlying = mock(SubscriberInterface.class);
+  // Initialized in setUp.
+  private StreamingPullSubscriber subscriber;
+  private MessageReceiver messageReceiver;
+  private ApiService.Listener errorListener;
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+  private static List<PubsubMessage> messagesFor(List<ReceivedMessage> received) {
+    return received.stream().map(ReceivedMessage::getMessage).collect(Collectors.toList());
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    when(underlying.startAsync()).thenReturn(underlying);
+    when(underlyingFactory.newSubscriber(any()))
+        .thenAnswer(
+            args -> {
+              messageReceiver = args.getArgument(0);
+              return underlying;
+            });
+    doAnswer(
+            (Answer<Void>)
+                args -> {
+                  errorListener = args.getArgument(0);
+                  return null;
+                })
+        .when(underlying)
+        .addListener(any(), any());
+
+    subscriber = new StreamingPullSubscriber(underlyingFactory);
+
+    InOrder inOrder = inOrder(underlyingFactory, underlying);
+    inOrder.verify(underlyingFactory).newSubscriber(any());
+    inOrder.verify(underlying).addListener(any(), any());
+    inOrder.verify(underlying).startAsync();
+    inOrder.verify(underlying).awaitRunning();
+
+    assertThat(messageReceiver).isNotNull();
+    assertThat(errorListener).isNotNull();
+  }
+
+  @Test
+  public void closeStops() {
+    when(underlying.stopAsync()).thenReturn(underlying);
+    subscriber.close();
+    verify(underlying).stopAsync();
+    verify(underlying).awaitTerminated();
+  }
+
+  @Test
+  public void pullAfterErrorThrows() {
+    ApiException expected = new CheckedApiException(Code.INTERNAL).underlying;
+    errorListener.failed(null, expected);
+    ExecutionException e = assertThrows(ExecutionException.class, () -> subscriber.pull().get());
+    assertThat(expected).isEqualTo(e.getCause());
+  }
+
+  @Test
+  public void pullBeforeErrorThrows() throws Exception {
+    ApiException expected = new CheckedApiException(Code.INTERNAL).underlying;
+    Future<List<ReceivedMessage>> future = subscriber.pull();
+    Thread.sleep(1000);
+    assertThat(future.isDone()).isFalse();
+
+    errorListener.failed(null, expected);
+    ExecutionException e = assertThrows(ExecutionException.class, future::get);
+    assertThat(expected).isEqualTo(e.getCause());
+  }
+
+  @Test
+  public void pullSuccess() throws Exception {
+    PubsubMessage message = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    Future<List<ReceivedMessage>> future = executorService.submit(() -> subscriber.pull().get());
+    messageReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+    assertThat(messagesFor(future.get())).isEqualTo(ImmutableList.of(message));
+  }
+
+  @Test
+  public void pullMultiple() throws Exception {
+    PubsubMessage message1 = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    PubsubMessage message2 = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    messageReceiver.receiveMessage(message1, mock(AckReplyConsumer.class));
+    messageReceiver.receiveMessage(message2, mock(AckReplyConsumer.class));
+    assertThat(messagesFor(subscriber.pull().get())).isEqualTo(ImmutableList.of(message1, message2));
+  }
+
+  @Test
+  public void pullMessageWhenError() {
+    ApiException expected = new CheckedApiException(Code.INTERNAL).underlying;
+    errorListener.failed(null, expected);
+    ExecutionException e = assertThrows(ExecutionException.class, () -> subscriber.pull().get());
+    assertThat(e.getCause()).isEqualTo(expected);
+  }
+
+  @Test
+  public void pullMessagePrioritizeErrorOverExistingMessage() {
+    ApiException expected = new CheckedApiException(Code.INTERNAL).underlying;
+    errorListener.failed(null, expected);
+    PubsubMessage message = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    messageReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+
+    ExecutionException e = assertThrows(ExecutionException.class, () -> subscriber.pull().get());
+    assertThat(e.getCause()).isEqualTo(expected);
+  }
+
+  @Test
+  public void pullThenAck() throws Exception {
+    PubsubMessage message = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    Future<List<ReceivedMessage>> future = executorService.submit(() -> subscriber.pull().get());
+    AckReplyConsumer ackReplyConsumer = mock(AckReplyConsumer.class);
+    messageReceiver.receiveMessage(message, ackReplyConsumer);
+    List<ReceivedMessage> batch = future.get();
+    assertThat(batch.size()).isEqualTo(1);
+    ReceivedMessage received = batch.get(0);
+    assertThat(received.getMessage()).isEqualTo(message);
+    verify(ackReplyConsumer, times(0)).ack();
+    // Invalid ack id ignored.
+    subscriber.ackMessages(ImmutableList.of("not a real ack id", received.getAckId())).get();
+    verify(ackReplyConsumer, times(1)).ack();
+  }
+
+  @Test
+  public void multiAck() throws Exception {
+    PubsubMessage message1 = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("abc")).build();
+    PubsubMessage message2 = PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("def")).build();
+    AckReplyConsumer ackReplyConsumer1 = mock(AckReplyConsumer.class);
+    AckReplyConsumer ackReplyConsumer2 = mock(AckReplyConsumer.class);
+    messageReceiver.receiveMessage(message1, ackReplyConsumer1);
+    messageReceiver.receiveMessage(message2, ackReplyConsumer2);
+    List<ReceivedMessage> batch = subscriber.pull().get();
+    assertThat(batch.size()).isEqualTo(2);
+    ReceivedMessage received1 = batch.get(0);
+    ReceivedMessage received2 = batch.get(1);
+    assertThat(received1.getMessage()).isEqualTo(message1);
+    assertThat(received2.getMessage()).isEqualTo(message2);
+    verify(ackReplyConsumer1, times(0)).ack();
+    verify(ackReplyConsumer2, times(0)).ack();
+    subscriber.ackMessages(ImmutableList.of(received2.getAckId(), received1.getAckId())).get();
+    verify(ackReplyConsumer1, times(1)).ack();
+    verify(ackReplyConsumer2, times(1)).ack();
+    // Duplicate ack ignored.
+    subscriber.ackMessages(ImmutableList.of(received2.getAckId(), received1.getAckId())).get();
+    verify(ackReplyConsumer1, times(1)).ack();
+    verify(ackReplyConsumer2, times(1)).ack();
+  }
+}


### PR DESCRIPTION
Also rework interfaces to not be tightly coupled with pull requests.

The implementation here is largely copied from the Pub/Sub Lite BlockingPullSubscriberImpl (https://github.com/googleapis/java-pubsublite/blob/master/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/BlockingPullSubscriberImpl.java) with modifications made to make it work with Cloud Pub/Sub clients instead of Pub/Sub lite wire clients.