### PR TITLE
Make the maximum buffer size 9.5 MB instead of 10 MB to prevent errors.

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -46,7 +46,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final String MAX_TOTAL_TIMEOUT_MS = "maxTotalTimeoutMs";
   public static final String MAX_SHUTDOWN_TIMEOUT_MS = "maxShutdownTimeoutMs";
   public static final int DEFAULT_MAX_BUFFER_SIZE = 100;
-  public static final long DEFAULT_MAX_BUFFER_BYTES = 10000000L;
+  public static final long DEFAULT_MAX_BUFFER_BYTES = 9500000L;
   public static final int DEFAULT_DELAY_THRESHOLD_MS = 100;
   public static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
   public static final int DEFAULT_TOTAL_TIMEOUT_MS = 60000;


### PR DESCRIPTION
Fixes: #267