### PR TITLE
Add blocking flow controls to the PubSub Sink connector

### DIFF
--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -124,6 +124,8 @@ Connector supports the following configs:
 | cps.endpoint | String | "pubsub.googleapis.com:443" | The [Cloud Pub/Sub endpoint](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints) to use. |
 | maxBufferSize | Integer | 100 | The maximum number of messages that can be received for the messages on a topic partition before publishing them to Cloud Pub/Sub. |
 | maxBufferBytes | Long | 10000000 | The maximum number of bytes that can be received for the messages on a topic partition before publishing them to Cloud Pub/Sub. |
+| maxOutstandingRequestBytes | Long | Long.MAX_VALUE | The maximum number of outstanding bytes for incomplete and unsent messages before the publisher will block further publishing. |
+| maxOutstandingMessages | Long | Long.MAX_VALUE | The maximum number of incomplete and unsent messages before the publisher will block further publishing. |
 | maxDelayThresholdMs | Integer | 100 | The maximum amount of time to wait to reach maxBufferSize or maxBufferBytes before publishing outstanding messages to Cloud Pub/Sub. |
 | maxRequestTimeoutMs | Integer | 10000 | The timeout for individual publish requests to Cloud Pub/Sub. |
 | maxTotalTimeoutMs | Integer | 60000| The total timeout for a call to publish (including retries) to Cloud Pub/Sub. |

--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -41,6 +41,8 @@ public class CloudPubSubSinkConnector extends SinkConnector {
 
   public static final String MAX_BUFFER_SIZE_CONFIG = "maxBufferSize";
   public static final String MAX_BUFFER_BYTES_CONFIG = "maxBufferBytes";
+  public static final String MAX_OUTSTANDING_REQUEST_BYTES = "maxOutstandingRequestBytes";
+  public static final String MAX_OUTSTANDING_MESSAGES = "maxOutstandingMessages";
   public static final String MAX_DELAY_THRESHOLD_MS = "delayThresholdMs";
   public static final String MAX_REQUEST_TIMEOUT_MS = "maxRequestTimeoutMs";
   public static final String MAX_TOTAL_TIMEOUT_MS = "maxTotalTimeoutMs";
@@ -51,6 +53,8 @@ public class CloudPubSubSinkConnector extends SinkConnector {
   public static final int DEFAULT_REQUEST_TIMEOUT_MS = 10000;
   public static final int DEFAULT_TOTAL_TIMEOUT_MS = 60000;
   public static final int DEFAULT_SHUTDOWN_TIMEOUT_MS = 60000;
+  public static final long DEFAULT_MAX_OUTSTANDING_REQUEST_BYTES = Long.MAX_VALUE;
+  public static final long DEFAULT_MAX_OUTSTANDING_MESSAGES = Long.MAX_VALUE;
   public static final String CPS_MESSAGE_BODY_NAME = "messageBodyName";
   public static final String DEFAULT_MESSAGE_BODY_NAME = "cps_message_body";
   public static final String PUBLISH_KAFKA_METADATA = "metadata.publish";
@@ -163,6 +167,18 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             Importance.MEDIUM,
             "The maximum number of bytes that can be received for the messages on a topic "
                 + "partition before publishing the messages to Cloud Pub/Sub.")
+        .define(MAX_OUTSTANDING_REQUEST_BYTES,
+            Type.LONG,
+            DEFAULT_MAX_OUTSTANDING_REQUEST_BYTES,
+            Importance.MEDIUM,
+            "The maximum outstanding bytes from incomplete requests before the task blocks."
+        )
+        .define(MAX_OUTSTANDING_MESSAGES,
+            Type.LONG,
+            DEFAULT_MAX_OUTSTANDING_MESSAGES,
+            Importance.MEDIUM,
+            "The maximum outstanding incomplete messages before the task blocks."
+        )
         .define(
             MAX_DELAY_THRESHOLD_MS,
             Type.INT,


### PR DESCRIPTION
Allowing the flow controls to limit the max outstanding bytes and elements. During large traffic spikes, we have observed Connect playing messages into the PubSub producer client as fast as possible resulting in several GB of off heap usage causing OOM errors. Configuring the connector to block on maxOutstandingRequestBytes should prevent this and stop polling until space is available.

We've tested this both with  the default and with a specified low maxOutstandingRequestBytes in our loadtest environment and observed it working as expected.

I've set the default values to Long. MAX_VALUE to effectively preserve the existing behavior for anyone that may not want this change, but I'm open to setting these to a reasonable value if we have some consensus on what that is.