### PR TITLE
Sink Connector should publish all outstanding messages on flush

### DIFF
--- a/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/kafka-connector/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -334,6 +334,8 @@ public class CloudPubSubSinkTask extends SinkTask {
 
   @Override
   public void flush(Map<TopicPartition, OffsetAndMetadata> partitionOffsets) {
+    // Publish the incomplete batch now instead of waiting for the maxDelayThresholdMs
+    publisher.publishAllOutstanding();
     log.debug("Flushing...");
     // Process results of all the outstanding futures specified by each TopicPartition.
     for (Map.Entry<TopicPartition, OffsetAndMetadata> partitionOffset :

--- a/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/kafka-connector/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -354,6 +354,7 @@ public class CloudPubSubSinkTaskTest {
     when(publisher.publish(any(PubsubMessage.class))).thenReturn(goodFuture);
     task.put(records);
     task.flush(partitionOffsets);
+    verify(publisher, times(1)).publishAllOutstanding();
     verify(publisher, times(2)).publish(any(PubsubMessage.class));
     verify(goodFuture, times(2)).addListener(any(Runnable.class), any(Executor.class));
   }
@@ -372,6 +373,7 @@ public class CloudPubSubSinkTaskTest {
     when(publisher.publish(any(PubsubMessage.class))).thenReturn(badFuture);
     task.put(records);
     task.flush(partitionOffsets);
+    verify(publisher, times(1)).publishAllOutstanding();
     verify(publisher, times(1)).publish(any(PubsubMessage.class));
     verify(badFuture, times(1)).addListener(any(Runnable.class), any(Executor.class));
   }
@@ -602,6 +604,7 @@ public class CloudPubSubSinkTaskTest {
     records = getSampleRecords();
     task.put(records);
     task.flush(partitionOffsets);
+    verify(publisher, times(2)).publishAllOutstanding();
     verify(publisher, times(4)).publish(any(PubsubMessage.class));
     verify(badFuture, times(2)).addListener(any(Runnable.class), any(Executor.class));
     verify(goodFuture, times(2)).addListener(any(Runnable.class), any(Executor.class));


### PR DESCRIPTION
When flush is called with a non-full batch, the publisher client may wait up to maxDelayThresholdMs before publishing the remaining messages introducing unnecessary tail latency on every flush. This change will force those messages to be published at the start of the flush call.