### PR TITLE
Add more info to logs

### DIFF
--- a/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/resource_controllers/PubsubResourceController.java
+++ b/load-test-framework/src/main/java/com/google/pubsub/flic/controllers/resource_controllers/PubsubResourceController.java
@@ -58,13 +58,13 @@ public class PubsubResourceController extends ResourceController {
           .execute();
     } catch (GoogleJsonResponseException e) {
       if (e.getStatusCode() != HttpStatus.SC_CONFLICT) {
-        log.error("Error creating subscription");
+        log.error("Error creating topic {}", topic);
         throw e;
       }
-      log.info("Topic already exists, reusing.");
+      log.info("Topic {} already exists, reusing.", topic);
     }
     for (String subscription : subscriptions) {
-      log.error("Creating subscription: " + subscription);
+      log.error("Creating subscription: {}", subscription);
       try {
         pubsub
             .projects()
@@ -72,7 +72,7 @@ public class PubsubResourceController extends ResourceController {
             .delete("projects/" + project + "/subscriptions/" + subscription)
             .execute();
       } catch (IOException e) {
-        log.debug("Error deleting subscription, assuming it has not yet been created.", e);
+        log.debug("Error deleting subscription {}: {}", subscription, e);
       }
       pubsub
           .projects()


### PR DESCRIPTION
Use SLF4J's parameterized messages for better
performance \[1\].

Also fix one log that incorrectly called a topic a subscription.

Logs before

```
ERROR-Error creating subscription
406 [pool-1-thread-4] ERROR com.google.pubsub.flic.controllers.resource_controllers.PubsubResourceController  - Error creating subscription
```

Logs after

```
ERROR-Error creating topic cloud-pubsub-loadtest
419 [pool-1-thread-3] ERROR com.google.pubsub.flic.controllers.resource_controllers.PubsubResourceController  - Error creating topic cloud-pubsub-loadtest
```

1: http://www.slf4j.org/faq.html#logging_performance