### PR TITLE
Update copy_tool.py

### DIFF
--- a/kafka-connector/copy_tool.py
+++ b/kafka-connector/copy_tool.py
@@ -17,9 +17,9 @@ import tarfile
 import tempfile
 import subprocess
 
-KAFKA_RELEASE = "2.6.0"
+KAFKA_RELEASE = "3.0.0"
 KAFKA_FOLDER = f"kafka_2.13-{KAFKA_RELEASE}"
-KAFKA_LINK = f"https://downloads.apache.org/kafka/{KAFKA_RELEASE}/{KAFKA_FOLDER}.tgz"
+KAFKA_LINK = f"https://dlcdn.apache.org/kafka/{KAFKA_RELEASE}/{KAFKA_FOLDER}.tgz"
 
 CONNECTOR_RELEASE = "v0.10-alpha"
 PUBSUB_CONNECTOR_LINK = f"https://github.com/GoogleCloudPlatform/pubsub/releases/download/{CONNECTOR_RELEASE}/pubsub-kafka-connector.jar"


### PR DESCRIPTION
Modified the download link/URL pattern for KAFKA_LINK to point to the latest version. The previous pattern/version was broken.