### PR TITLE
docs: remove kafka loadtest references in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ available are:
 * [Kafka Connector](https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector):
   Send and receive messages from [Apache Kafka](http://kafka.apache.org).
 * [Load Testing Framework](https://github.com/GoogleCloudPlatform/pubsub/tree/master/load-test-framework):
-  Set up comparative load tests between [Apache Kafka](http://kafka.apache.org)
-  and [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/), as well as
+  Set up benchmarking load tests for [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/), as well as
   between different clients on the same stack (e.g. Http/Json and gRPC clients
   for CPS). Currently, we only support maven version 3 and Java 8.
   If you're having a problem building with those versions, please reach out to us with your issue or solution.


### PR DESCRIPTION
We removed kafka support in https://github.com/GoogleCloudPlatform/pubsub/pull/304,