### PR TITLE
docs: deprecate kafka connector and add a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-[![Build Status](https://travis-ci.org/GoogleCloudPlatform/pubsub.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/pubsub) 
+[![Build Status](https://travis-ci.org/GoogleCloudPlatform/pubsub.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/pubsub)
 
 This repository contains open-source projects managed by the owners of
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/). The projects
 available are:
 
-* [Kafka Connector](https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector):
-  Send and receive messages from [Apache Kafka](http://kafka.apache.org).
 * [Load Testing Framework](https://github.com/GoogleCloudPlatform/pubsub/tree/master/load-test-framework):
   Set up comparative load tests between [Apache Kafka](http://kafka.apache.org)
   and [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/), as well as
@@ -14,7 +12,11 @@ available are:
   If you're having a problem building with those versions, please reach out to us with your issue or solution.
 * [Ordering Keys Prober](https://github.com/GoogleCloudPlatform/pubsub/tree/master/ordering-keys-prober):
   A reference implementation for how to use ordering keys effectively.
-* [DEPRECATED Experimental high-performance client library](https://github.com/GoogleCloudPlatform/pubsub/tree/master/client):
+* DEPRECATED - [Kafka Connector](https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector):
+  Send and receive messages from [Apache Kafka](http://kafka.apache.org). *The
+  connector will have future release from its own [repo](https://github.com/googleapis/java-pubsub-group-kafka-connector/)
+  with [releases](https://github.com/googleapis/java-pubsub-group-kafka-connector/releases).*
+* DEPRECATED - [Experimental high-performance client library](https://github.com/GoogleCloudPlatform/pubsub/tree/master/client):
   For Java along with [samples](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets).
 
 Note: To build each of these projects, we recommend using maven.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ available are:
   A reference implementation for how to use ordering keys effectively.
 * DEPRECATED - [Kafka Connector](https://github.com/GoogleCloudPlatform/pubsub/tree/master/kafka-connector):
   Send and receive messages from [Apache Kafka](http://kafka.apache.org). *The
-  connector will have future release from its own [repo](https://github.com/googleapis/java-pubsub-group-kafka-connector/)
-  with [releases](https://github.com/googleapis/java-pubsub-group-kafka-connector/releases).*
+  connector will have future release from its own [repo](https://github.com/googleapis/java-pubsub-group-kafka-connector/).*
 * DEPRECATED - [Experimental high-performance client library](https://github.com/GoogleCloudPlatform/pubsub/tree/master/client):
   For Java along with [samples](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets).
 

--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -1,8 +1,9 @@
 # Deprecation Notice
 
-***2022-09-26: We have moved this directory to its own repo at
+***2022-09-26: This project has moved to a top-level repository at
 https://github.com/googleapis/java-pubsub-group-kafka-connector/
-for future releases of the Pub/Sub Kafka connector.*** 
+for future releases of the Pub/Sub Kafka connector. See #325 for
+the announcement.*** 
 
 ### Introduction
 

--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -1,3 +1,9 @@
+# Deprecation Notice
+
+***2022-09-26: We have moved everything in this directory to its own repo at
+https://github.com/googleapis/java-pubsub-group-kafka-connector/
+for future releases of the Pub/Sub Kafka connector.*** 
+
 ### Introduction
 
 The CloudPubSubConnector is a connector to be used with

--- a/kafka-connector/README.md
+++ b/kafka-connector/README.md
@@ -1,6 +1,6 @@
 # Deprecation Notice
 
-***2022-09-26: We have moved everything in this directory to its own repo at
+***2022-09-26: We have moved this directory to its own repo at
 https://github.com/googleapis/java-pubsub-group-kafka-connector/
 for future releases of the Pub/Sub Kafka connector.*** 
 


### PR DESCRIPTION
Set up redirect for Kafka connector, which has been moved to https://github.com/googleapis/java-pubsub-group-kafka-connector and has a release pending for the week of 9/26. 