### PR TITLE
Add flow control setting to source builder

### DIFF
--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
@@ -16,7 +16,6 @@
 package com.google.pubsub.flink;
 
 import com.google.api.gax.batching.FlowControlSettings;
-import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
@@ -64,8 +63,6 @@ public abstract class PubSubSource<OutputT>
 
   public abstract Optional<Long> maxOutstandingMessagesBytes();
 
-  public abstract Optional<LimitExceededBehavior> limitExceededBehavior();
-
   public abstract Optional<Credentials> credentials();
 
   public static <OutputT> Builder<OutputT> builder() {
@@ -81,7 +78,6 @@ public abstract class PubSubSource<OutputT>
             .setMaxOutstandingElementCount(maxOutstandingMessagesCount().or(1000L))
             .setMaxOutstandingRequestBytes(
                 maxOutstandingMessagesBytes().or(100L * 1024L * 1024L)) // 100MB
-            .setLimitExceededBehavior(limitExceededBehavior().or(LimitExceededBehavior.Block))
             .build());
     if (credentials().isPresent()) {
       builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials().get()));
@@ -170,9 +166,6 @@ public abstract class PubSubSource<OutputT>
     public abstract Builder<OutputT> setMaxOutstandingMessagesCount(Long count);
 
     public abstract Builder<OutputT> setMaxOutstandingMessagesBytes(Long bytes);
-
-    public abstract Builder<OutputT> setLimitExceededBehavior(
-        LimitExceededBehavior limitExceededBehavior);
 
     public abstract Builder<OutputT> setCredentials(Credentials credentials);
 

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
@@ -89,13 +89,6 @@ public class PubSubSourceTest {
   }
 
   @Test
-  public void build_invalidLimitExceededBehavior() throws Exception {
-    assertThrows(
-        NullPointerException.class,
-        () -> PubSubSource.<String>builder().setLimitExceededBehavior(null));
-  }
-
-  @Test
   public void build_invalidCreds() throws Exception {
     assertThrows(
         NullPointerException.class, () -> PubSubSource.<String>builder().setCredentials(null));

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
@@ -59,10 +59,14 @@ public class PubSubSourceTest {
   }
 
   @Test
-  public void build_invalidMaxOutstandingMessagesCount() throws Exception {
+  public void build_nullMaxOutstandingMessagesCountThrows() throws Exception {
     assertThrows(
         NullPointerException.class,
         () -> PubSubSource.<String>builder().setMaxOutstandingMessagesCount(null));
+  }
+
+  @Test
+  public void build_negativeMaxOutstandingMessagesCountThrows() throws Exception {
     PubSubSource.Builder<String> builder =
         PubSubSource.<String>builder()
             .setProjectName("project")
@@ -74,10 +78,14 @@ public class PubSubSourceTest {
   }
 
   @Test
-  public void build_invalidMaxOutstandingMessagesBytes() throws Exception {
+  public void build_nullMaxOutstandingMessagesBytesThrows() throws Exception {
     assertThrows(
         NullPointerException.class,
         () -> PubSubSource.<String>builder().setMaxOutstandingMessagesBytes(null));
+  }
+
+  @Test
+  public void build_negativeMaxOutstandingMessagesBytesThrows() throws Exception {
     PubSubSource.Builder<String> builder =
         PubSubSource.<String>builder()
             .setProjectName("project")

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
@@ -59,6 +59,43 @@ public class PubSubSourceTest {
   }
 
   @Test
+  public void build_invalidMaxOutstandingMessagesCount() throws Exception {
+    assertThrows(
+        NullPointerException.class,
+        () -> PubSubSource.<String>builder().setMaxOutstandingMessagesCount(null));
+    PubSubSource.Builder<String> builder =
+        PubSubSource.<String>builder()
+            .setProjectName("project")
+            .setSubscriptionName("subscription")
+            .setDeserializationSchema(
+                PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()))
+            .setMaxOutstandingMessagesCount(-1L);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  public void build_invalidMaxOutstandingMessagesBytes() throws Exception {
+    assertThrows(
+        NullPointerException.class,
+        () -> PubSubSource.<String>builder().setMaxOutstandingMessagesBytes(null));
+    PubSubSource.Builder<String> builder =
+        PubSubSource.<String>builder()
+            .setProjectName("project")
+            .setSubscriptionName("subscription")
+            .setDeserializationSchema(
+                PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()))
+            .setMaxOutstandingMessagesBytes(-1L);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  public void build_invalidLimitExceededBehavior() throws Exception {
+    assertThrows(
+        NullPointerException.class,
+        () -> PubSubSource.<String>builder().setLimitExceededBehavior(null));
+  }
+
+  @Test
   public void build_invalidCreds() throws Exception {
     assertThrows(
         NullPointerException.class, () -> PubSubSource.<String>builder().setCredentials(null));


### PR DESCRIPTION
Default flow control values are copied from the CPS client library. `FlowControlSettings` cannot be added as a builder option due to it not being serializable.

Max outstanding values are per-checkpoint. I plan to document how flow control works in a separate PR.