### PR TITLE
Add builder options to source/sink

### DIFF
--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
@@ -38,6 +38,10 @@ public abstract class PubSubSink<T> implements Sink<T> {
 
   public abstract Optional<Credentials> credentials();
 
+  public abstract Optional<Boolean> enableMessageOrdering();
+
+  public abstract Optional<String> endpoint();
+
   public static <T> Builder<T> builder() {
     return new AutoValue_PubSubSink.Builder<T>();
   }
@@ -46,6 +50,12 @@ public abstract class PubSubSink<T> implements Sink<T> {
     Publisher.Builder builder = Publisher.newBuilder(topicName.toString());
     if (credentials().isPresent()) {
       builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials().get()));
+    }
+    if (enableMessageOrdering().isPresent()) {
+      builder.setEnableMessageOrdering(enableMessageOrdering().get());
+    }
+    if (endpoint().isPresent()) {
+      builder.setEndpoint(endpoint().get());
     }
     return builder.build();
   }
@@ -74,6 +84,10 @@ public abstract class PubSubSink<T> implements Sink<T> {
         PubSubSerializationSchema<T> serializationSchema);
 
     public abstract Builder<T> setCredentials(Credentials credentials);
+
+    public abstract Builder<T> setEnableMessageOrdering(Boolean enableMessageOrdering);
+
+    public abstract Builder<T> setEndpoint(String endpoint);
 
     public abstract PubSubSink<T> build();
   }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
@@ -28,6 +28,13 @@ import java.io.IOException;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 
+/**
+ * Google Cloud Pub/Sub sink to publish messages to a Pub/Sub topic.
+ *
+ * <p>{@link PubSubSink} is constructed and configured using {@link Builder}. {@link PubSubSink}
+ * cannot be configured after it is built. See {@link Builder} for how {@link PubSubSink} can be
+ * configured.
+ */
 @AutoValue
 public abstract class PubSubSink<T> implements Sink<T> {
   public abstract String projectName();
@@ -74,19 +81,52 @@ public abstract class PubSubSink<T> implements Sink<T> {
         serializationSchema());
   }
 
+  /** Builder to construct {@link PubSubSink}. */
   @AutoValue.Builder
   public abstract static class Builder<T> {
+    /**
+     * Sets the GCP project ID that owns the topic to which messages are published.
+     *
+     * <p>Setting this option is required to build {@link PubSubSink}.
+     */
     public abstract Builder<T> setProjectName(String projectName);
 
+    /**
+     * Sets the Pub/Sub topic to which messages are published.
+     *
+     * <p>Setting this option is required to build {@link PubSubSink}.
+     */
     public abstract Builder<T> setTopicName(String topicName);
 
+    /**
+     * Sets the serialization schema used to serialize incoming data into a {@link PubsubMessage}.
+     *
+     * <p>Setting this option is required to build {@link PubSubSink}.
+     */
     public abstract Builder<T> setSerializationSchema(
         PubSubSerializationSchema<T> serializationSchema);
 
+    /**
+     * Sets the credentials used when publishing messages to Google Cloud Pub/Sub.
+     *
+     * <p>If not set, then Application Default Credentials are used for authentication.
+     */
     public abstract Builder<T> setCredentials(Credentials credentials);
 
+    /**
+     * Sets whether to enable ordered publishing.
+     *
+     * <p>The default value is {@code false}. This must be set to {@code true} when publishing an
+     * {@link PubsubMessage} with an ordering key set.
+     */
     public abstract Builder<T> setEnableMessageOrdering(Boolean enableMessageOrdering);
 
+    /**
+     * Sets the Google Cloud Pub/Sub service endpoint to which messages are published.
+     *
+     * <p>Defaults to connecting to the global endpoint, which routes requests to the nearest
+     * regional endpoint.
+     */
     public abstract Builder<T> setEndpoint(String endpoint);
 
     public abstract PubSubSink<T> build();

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
@@ -67,7 +67,11 @@ public abstract class PubSubSource<OutputT>
 
   public abstract Optional<Long> maxOutstandingMessagesBytes();
 
+  public abstract Optional<Integer> parallelPullCount();
+
   public abstract Optional<Credentials> credentials();
+
+  public abstract Optional<String> endpoint();
 
   public static <OutputT> Builder<OutputT> builder() {
     return new AutoValue_PubSubSource.Builder<OutputT>();
@@ -83,8 +87,14 @@ public abstract class PubSubSource<OutputT>
             .setMaxOutstandingRequestBytes(
                 maxOutstandingMessagesBytes().or(100L * 1024L * 1024L)) // 100MB
             .build());
+    if (parallelPullCount().isPresent()) {
+      builder.setParallelPullCount(parallelPullCount().get());
+    }
     if (credentials().isPresent()) {
       builder.setCredentialsProvider(FixedCredentialsProvider.create(credentials().get()));
+    }
+    if (endpoint().isPresent()) {
+      builder.setEndpoint(endpoint().get());
     }
 
     // Assume we should connect to the Pub/Sub emulator if PUBSUB_EMULATOR_HOST is set.
@@ -181,7 +191,11 @@ public abstract class PubSubSource<OutputT>
 
     public abstract Builder<OutputT> setMaxOutstandingMessagesBytes(Long bytes);
 
+    public abstract Builder<OutputT> setParallelPullCount(Integer parallelPullCount);
+
     public abstract Builder<OutputT> setCredentials(Credentials credentials);
+
+    public abstract Builder<OutputT> setEndpoint(String endpoint);
 
     abstract PubSubSource<OutputT> autoBuild();
 
@@ -193,6 +207,9 @@ public abstract class PubSubSource<OutputT>
       Preconditions.checkArgument(
           source.maxOutstandingMessagesBytes().or(1L) > 0,
           "maxOutstandingMessagesBytes, if set, must be a value greater than 0.");
+      Preconditions.checkArgument(
+          source.parallelPullCount().or(1) > 0,
+          "parallelPullCount, if set, must be a value greater than 0.");
       return source;
     }
   }

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSinkTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSinkTest.java
@@ -60,4 +60,16 @@ public class PubSubSinkTest {
     assertThrows(
         NullPointerException.class, () -> PubSubSink.<String>builder().setCredentials(null));
   }
+
+  @Test
+  public void build_invalidEnableMessageOrdering() throws Exception {
+    assertThrows(
+        NullPointerException.class,
+        () -> PubSubSink.<String>builder().setEnableMessageOrdering(null));
+  }
+
+  @Test
+  public void build_invalidEndpoint() throws Exception {
+    assertThrows(NullPointerException.class, () -> PubSubSink.<String>builder().setEndpoint(null));
+  }
 }

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/PubSubSourceTest.java
@@ -97,8 +97,33 @@ public class PubSubSourceTest {
   }
 
   @Test
+  public void build_nullParallelPullCountThrows() throws Exception {
+    assertThrows(
+        NullPointerException.class,
+        () -> PubSubSource.<String>builder().setParallelPullCount(null));
+  }
+
+  @Test
+  public void build_negativeParallelPullCountThrows() throws Exception {
+    PubSubSource.Builder<String> builder =
+        PubSubSource.<String>builder()
+            .setProjectName("project")
+            .setSubscriptionName("subscription")
+            .setDeserializationSchema(
+                PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()))
+            .setParallelPullCount(-1);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
   public void build_invalidCreds() throws Exception {
     assertThrows(
         NullPointerException.class, () -> PubSubSource.<String>builder().setCredentials(null));
+  }
+
+  @Test
+  public void build_invalidEndpoint() throws Exception {
+    assertThrows(
+        NullPointerException.class, () -> PubSubSource.<String>builder().setEndpoint(null));
   }
 }


### PR DESCRIPTION
These are commonly used builder options in the underlying Pub/Sub client library. 