### PR TITLE
Add at-least-once delivery guarantee to CPS source

### DIFF
--- a/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
+++ b/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
@@ -68,8 +68,9 @@ either at the Google Cloud project-level or the Pub/Sub resource-level.
 
 ## Pub/Sub Source
 
-Pub/Sub source streams data from a single Google Cloud Pub/Sub subscription. The
-sample below shows the minimal configurations required to build Pub/Sub source.
+Pub/Sub source streams data from a single Google Cloud Pub/Sub subscription with
+an at-least-once guarantee. The sample below shows the minimal configurations
+required to build Pub/Sub source.
 
 ```java
 PubSubSource.<String>builder()
@@ -241,8 +242,9 @@ extended to at most 1h.
 
 ## Pub/Sub Sink
 
-Pub/Sub sink publishes data to a single Google Cloud Pub/Sub topic. The sample
-below shows the minimal configurations required to build Pub/Sub sink.
+Pub/Sub sink publishes data to a single Google Cloud Pub/Sub topic with an
+at-least-once guarantee. The sample below shows the minimal configurations
+required to build Pub/Sub sink.
 
 ```java
 PubSubSink.<String>builder()
@@ -262,12 +264,6 @@ serialized to
 For convenience, `PubSubSserializationSchema.dataOnly(SerializationSchema<T>
 schema)` can be used if `PubsubMessage.data` is the only field used when
 publishing messages.
-
-### Publish Guarantees
-
-There are currently no guarantees that messages are published. Pub/Sub sink uses
-a fire-and-forget publishing strategy to maximize throughput, at the cost of
-possible data loss.
 
 ### All Options
 

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/enumerator/PubSubSplitEnumerator.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/enumerator/PubSubSplitEnumerator.java
@@ -91,7 +91,8 @@ public class PubSubSplitEnumerator
     HashMap<Integer, List<SubscriptionSplit>> newAssignments = new HashMap<>();
     for (Integer reader : registeredReaders) {
       if (!readersWithAssignments.containsKey(reader)) {
-        SubscriptionSplit newSplit = SubscriptionSplit.create(subscriptionName);
+        SubscriptionSplit newSplit =
+            SubscriptionSplit.create(subscriptionName, Integer.toString(reader));
         readersWithAssignments.put(reader, newSplit);
         newAssignments.put(reader, Collections.singletonList(newSplit));
       }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/AckTracker.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/AckTracker.java
@@ -23,4 +23,6 @@ public interface AckTracker {
   void addCheckpoint(long checkpointId);
 
   void notifyCheckpointComplete(long checkpointId);
+
+  void nackAll();
 }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTracker.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTracker.java
@@ -31,7 +31,7 @@ public class PubSubAckTracker implements AckTracker {
 
   @Override
   public synchronized void addPendingAck(AckReplyConsumer ackReplyConsumer) {
-    this.pendingAcks.add(ackReplyConsumer);
+    pendingAcks.add(ackReplyConsumer);
   }
 
   @Override
@@ -47,5 +47,17 @@ public class PubSubAckTracker implements AckTracker {
       toAck.addAll(checkpoints.remove(checkpoints.firstKey()));
     }
     toAck.forEach((ackReplyConsumer) -> ackReplyConsumer.ack());
+  }
+
+  @Override
+  public synchronized void nackAll() {
+    pendingAcks.forEach((ackReplyConsumer) -> ackReplyConsumer.nack());
+    pendingAcks.clear();
+    checkpoints
+        .values()
+        .forEach(
+            (ackReplyConsumers) ->
+                ackReplyConsumers.forEach((ackReplyConsumer) -> ackReplyConsumer.nack()));
+    checkpoints.clear();
   }
 }

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTrackerTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTrackerTest.java
@@ -85,4 +85,18 @@ public class PubSubAckTrackerTest {
     verify(mockAck1).ack();
     verify(mockAck2).ack();
   }
+
+  @Test
+  public void nackAll_pendingAndIncompleteCheckpointAcks() throws Exception {
+    AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
+    ackTracker.addPendingAck(mockAck1);
+    ackTracker.addCheckpoint(1L);
+    AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
+    ackTracker.addPendingAck(mockAck2);
+
+    ackTracker.nackAll();
+
+    verify(mockAck1).nack();
+    verify(mockAck2).nack();
+  }
 }


### PR DESCRIPTION
This PR addresses a lack of at-least-once guarantee in PubSubSource and undesired behavior when recovering from a fault.

This PR adds an at-least-once guarantee by deferring adding messages to the AckTracker from when they are delivered to when SplitReader calls fetch on them. This prevents messages from being added to a checkpoint before the SplitReader fetches them.

When recovering from a fault, PubSubSplitReader would receive their previously assigned splits + new splits. Since splits are never finished (there's no notion of partitions in CPS), this would lead to each PubSubSplitReader accumulating addtion subscribers to manage whenever recovering from a failure. The ideal behavior is having a one-to-one mapping of subscriber clients to parallelism. This is achived by keying splits by assigned subtask ID instead of creating a UID for each split.

Additionally, PubSubSourceReader would occasionally not close within the default 30s deadline. This caused unmanaged subscriber clients to continuously extend their lease on messages that could not be processed in the background. From dozens of test iterations, nacking outstanding messages fixes this issue and allows messages to be redelivered and processed quickly after recovering from a fault.

I tested this PR using a sink that was configured to fail every 3 checkponts. There was no message loss across dozens of test runs.