### PR TITLE
Dockerize E2E emulator tests and add an E2E test for PubSubSink

### DIFF
--- a/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
+++ b/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
@@ -331,7 +331,9 @@ Instead of integration tests reading from and writing to production Google Cloud
 Pub/Sub, tests can run against a local instance of the
 [Pub/Sub emulator](https://cloud.google.com/pubsub/docs/emulator). Pub/Sub
 source and sink will automatically try connecting to the emulator if the
-environment variable `PUBSUB_EMULATOR_HOST` is set.
+environment variable `PUBSUB_EMULATOR_HOST` is set. Alternatively, you can
+manually set the emulator endpoint in your builder by calling
+`.setEndpoint(EmulatorEndpoint.toEmulatorEndpoint("localhost:8085"))`.
 
 Steps to run tests against the Pub/Sub emulator:
 
@@ -346,3 +348,7 @@ Steps to run tests against the Pub/Sub emulator:
     where the emulator is running. For example, if the emulator is listening on
     port 8085 and running on the same machine as the test, set
     `PUBSUB_EMULATOR_HOST=localhost:8085`.
+
+The emulator can also be started within a Docker container while testing. The
+tests under `flink-connector/flink-connector-gcp-pubsub-e2e-tests/` illustrate
+how to do this.

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/pom.xml
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/pom.xml
@@ -73,6 +73,11 @@
       <!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>gcloud</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/DockerImageVersions.java
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/DockerImageVersions.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.pubsub.flink;
+
+/**
+ * Utility class for defining the image names and versions of Docker containers used during the Java
+ * tests. The names/versions are centralised here in order to make testing version updates easier,
+ * as well as to provide a central file to use as a key when caching testing Docker files.
+ */
+public class DockerImageVersions {
+  public static final String GOOGLE_CLOUD_PUBSUB_EMULATOR =
+      "gcr.io/google.com/cloudsdktool/cloud-sdk:379.0.0";
+}

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubEmulatorHelper.java
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubEmulatorHelper.java
@@ -41,10 +41,14 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /** Helper for local E2E testing against a Cloud Pub/Sub emulator. */
 public final class PubSubEmulatorHelper {
   private static final Logger LOG = LoggerFactory.getLogger(PubSubEmulatorHelper.class);
+
+  private static PubSubEmulatorContainer container;
 
   private static TransportChannel channel;
   private static TransportChannelProvider channelProvider;
@@ -54,12 +58,19 @@ public final class PubSubEmulatorHelper {
 
   private PubSubEmulatorHelper() {}
 
-  public static String getEmulatorEndpoint() throws IllegalStateException {
+  public static String getEmulatorEndpoint() {
     String hostport = System.getenv("PUBSUB_EMULATOR_HOST");
-    if (hostport == null) {
-      throw new IllegalStateException("Environment variable PUBSUB_EMULATOR_HOST not set.");
+    if (hostport != null) {
+      return hostport;
     }
-    return hostport;
+
+    if (container == null) {
+      container =
+          new PubSubEmulatorContainer(
+              DockerImageName.parse(DockerImageVersions.GOOGLE_CLOUD_PUBSUB_EMULATOR));
+      container.start();
+    }
+    return container.getEmulatorEndpoint();
   }
 
   public static TransportChannelProvider getTransportChannelProvider()

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubSinkEmulatorTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubSinkEmulatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.pubsub.flink;
+
+import com.google.pubsub.flink.util.EmulatorEndpoint;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.TopicName;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** E2E test for PubSubSink using a local Pub/Sub emulator. */
+public class PubSubSinkEmulatorTest extends TestLogger {
+  private final TopicName topic = TopicName.of("test-project", "test-topic");
+  private final SubscriptionName subscription =
+      SubscriptionName.of("test-project", "test-subscription");
+
+  @Test
+  public void testPubSubSink() throws Exception {
+    PubSubEmulatorHelper.createTopic(topic);
+    PubSubEmulatorHelper.createSubscription(subscription, topic);
+    List<String> messageInput = Arrays.asList("msg-1", "msg-2", "msg-3", "msg-4", "msg-5");
+    final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.enableCheckpointing(100);
+    env.setParallelism(1);
+    DataStream<String> stream = env.fromCollection(messageInput);
+    stream
+        .sinkTo(
+            PubSubSink.<String>builder()
+                .setSerializationSchema(
+                    PubSubSerializationSchema.dataOnly(new SimpleStringSchema()))
+                .setProjectName(topic.getProject())
+                .setTopicName(topic.getTopic())
+                .setEndpoint(
+                    EmulatorEndpoint.toEmulatorEndpoint(PubSubEmulatorHelper.getEmulatorEndpoint()))
+                .build())
+        .name("PubSubSink");
+    env.execute("PubSubSinkEmulatorTest");
+
+    List<PubsubMessage> messageOutput =
+        PubSubEmulatorHelper.pullAndAckMessages(
+            subscription,
+            /* expectedMessageCount= */ messageInput.size(),
+            /* deadlineSeconds= */ 60);
+    List<String> messageDataOutput =
+        messageOutput.stream()
+            .map(message -> message.getData().toStringUtf8())
+            .collect(Collectors.toList());
+
+    assertEquals(
+        "Did not receive expected number of messages.", messageInput.size(), messageOutput.size());
+    for (final String msg : messageInput) {
+      assertTrue("Missing " + msg, messageDataOutput.contains(msg));
+    }
+  }
+}

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubSourceEmulatorTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/src/test/java/com/google/pubsub/flink/PubSubSourceEmulatorTest.java
@@ -16,6 +16,7 @@
 
 package com.google.pubsub.flink;
 
+import com.google.pubsub.flink.util.EmulatorEndpoint;
 import com.google.pubsub.v1.SubscriptionName;
 import com.google.pubsub.v1.TopicName;
 import java.util.ArrayList;
@@ -56,6 +57,8 @@ public class PubSubSourceEmulatorTest extends TestLogger {
                     PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()))
                 .setProjectName(subscription.getProject())
                 .setSubscriptionName(subscription.getSubscription())
+                .setEndpoint(
+                    EmulatorEndpoint.toEmulatorEndpoint(PubSubEmulatorHelper.getEmulatorEndpoint()))
                 .build(),
             WatermarkStrategy.noWatermarks(),
             "PubSubEmulatorSource");

--- a/flink-connector/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector/flink-connector-gcp-pubsub/pom.xml
@@ -129,7 +129,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
@@ -16,6 +16,9 @@
 package com.google.pubsub.flink;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsub.v1.Publisher;
@@ -23,7 +26,9 @@ import com.google.common.base.Optional;
 import com.google.pubsub.flink.internal.sink.PubSubFlushablePublisher;
 import com.google.pubsub.flink.internal.sink.PubSubPublisherCache;
 import com.google.pubsub.flink.internal.sink.PubSubSinkWriter;
+import com.google.pubsub.flink.util.EmulatorEndpoint;
 import com.google.pubsub.v1.TopicName;
+import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
@@ -63,6 +68,15 @@ public abstract class PubSubSink<T> implements Sink<T> {
     }
     if (endpoint().isPresent()) {
       builder.setEndpoint(endpoint().get());
+    }
+
+    String emulatorEndpoint = EmulatorEndpoint.getEmulatorEndpoint(endpoint());
+    if (emulatorEndpoint != null) {
+      builder.setCredentialsProvider(NoCredentialsProvider.create());
+      builder.setChannelProvider(
+          FixedTransportChannelProvider.create(
+              GrpcTransportChannel.create(
+                  ManagedChannelBuilder.forTarget(emulatorEndpoint).usePlaintext().build())));
     }
     return builder.build();
   }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
@@ -36,6 +36,7 @@ import com.google.pubsub.flink.internal.source.reader.PubSubSplitReader;
 import com.google.pubsub.flink.internal.source.split.SubscriptionSplit;
 import com.google.pubsub.flink.internal.source.split.SubscriptionSplitSerializer;
 import com.google.pubsub.flink.proto.PubSubEnumeratorCheckpoint;
+import com.google.pubsub.flink.util.EmulatorEndpoint;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import io.grpc.ManagedChannelBuilder;
 import java.util.HashMap;
@@ -104,8 +105,7 @@ public abstract class PubSubSource<OutputT>
       builder.setEndpoint(endpoint().get());
     }
 
-    // Assume we should connect to the Pub/Sub emulator if PUBSUB_EMULATOR_HOST is set.
-    String emulatorEndpoint = System.getenv("PUBSUB_EMULATOR_HOST");
+    String emulatorEndpoint = EmulatorEndpoint.getEmulatorEndpoint(endpoint());
     if (emulatorEndpoint != null) {
       builder.setCredentialsProvider(NoCredentialsProvider.create());
       builder.setChannelProvider(

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/util/EmulatorEndpoint.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/util/EmulatorEndpoint.java
@@ -33,6 +33,7 @@ public class EmulatorEndpoint {
   @Nullable
   public static String getEmulatorEndpoint(Optional<String> endpoint) {
     String emulatorEndpoint = null;
+    // Prioritize using an emulator endpoint set in env var PUBSUB_EMULATOR_HOST.
     if ((emulatorEndpoint = System.getenv("PUBSUB_EMULATOR_HOST")) != null) {
       return emulatorEndpoint;
     }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/util/EmulatorEndpoint.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/util/EmulatorEndpoint.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.pubsub.flink.util;
+
+import com.google.common.base.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class used to help connect {@link PubSubSink} and {@link PubSubSource} to a Google Cloud
+ * Pub/Sub emulator.
+ */
+public class EmulatorEndpoint {
+  public static final String EMULATOR_ENDPOINT_PREFIX = "emulator:///";
+
+  public static String toEmulatorEndpoint(String endpoint) {
+    return EMULATOR_ENDPOINT_PREFIX + endpoint;
+  }
+
+  @Nullable
+  public static String getEmulatorEndpoint(Optional<String> endpoint) {
+    String emulatorEndpoint = null;
+    if ((emulatorEndpoint = System.getenv("PUBSUB_EMULATOR_HOST")) != null) {
+      return emulatorEndpoint;
+    }
+    if (endpoint.isPresent() && endpoint.get().startsWith(EMULATOR_ENDPOINT_PREFIX)) {
+      return endpoint.get().replaceFirst(EMULATOR_ENDPOINT_PREFIX, "");
+    }
+    return emulatorEndpoint;
+  }
+}

--- a/flink-connector/pom.xml
+++ b/flink-connector/pom.xml
@@ -72,6 +72,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.17.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
- Add support for source/sink connecting to an emulator using `builder.setEndpoint`
- In E2E tests, start a docker container with a running CPS emulator if the env var PUBSUB_EMULATOR_HOST is not set
- Write a simple E2E test where PubSubSink publishes to an emulator