### PR TITLE
Improve example Flink job and documentation

### DIFF
--- a/flink-connector/README.md
+++ b/flink-connector/README.md
@@ -1,20 +1,31 @@
 # Apache Flink Google Cloud Pub/Sub Connector
 
-This repository contains an **unofficial** Flink connector library that is
+Note: This connector library is separate from the library maintained by the
+Apache Flink community
+([https://github.com/apache/flink-connector-gcp-pubsub](https://github.com/apache/flink-connector-gcp-pubsub)).
+The Google Cloud Pub/Sub connector library documentation on
+[Apache Flink's website](https://nightlies.apache.org/flink/flink-docs-stable/docs/connectors/datastream/pubsub/)
+is **not** for this connector library.
+
+This repository contains a Google Cloud Pub/Sub Flink connector library that is
 maintained by the owners of Google Cloud Pub/Sub. This connector was designed to
 enable building Flink pipelines that scale to your streaming data analytics
 performance requirements. Reasons to use this connector include:
 
-*   Stream data from Google Cloud Pub/Sub with minimal latency and maximal
+*   Streaming data from Google Cloud Pub/Sub with minimal latency and maximal
     throughput by taking advantage of Google Cloud Pub/Sub's
     [StreamingPull API](https://cloud.google.com/pubsub/docs/pull#streamingpull_api)
-*   Process data at your pace with automatic
+*   Processing data at your pace with automatic
     [message lease extensions](https://cloud.google.com/pubsub/docs/lease-management)
-*   Using the latest Flink DataStream APIs, including the source API updated in
+*   Compatibility with the latest Flink version (currently
+    [Flink 1.19](https://flink.apache.org/2024/03/18/announcing-the-release-of-apache-flink-1.19/))
+    and DataStream APIs, including the source API updated in
     [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface)
 
-The official Apache Flink Google Cloud Pub/Sub connector is located at
-[https://github.com/apache/flink-connector-gcp-pubsub](https://github.com/apache/flink-connector-gcp-pubsub).
+Learn more about this connector in
+[`docs/content/docs/connectors/datastream/pubsub.md`](https://github.com/GoogleCloudPlatform/pubsub/blob/master/flink-connector/docs/content/docs/connectors/datastream/pubsub.md),
+which discusses it in depth. Still have questions? Please reach out to us by
+creating an issue with your question.
 
 ## Apache Flink
 
@@ -26,10 +37,10 @@ Learn more about Flink at [https://flink.apache.org/](https://flink.apache.org/)
 ## Using the Connector
 
 We are in the process of uploading the connector to a public respository. In the
-meantime, you can build the connector jar file from source to be packaged with
+meantime, you can build the connector JAR file from source to be packaged with
 your Flink deployment.
 
-### Building from Source
+### Building from Source {#building-from-source}
 
 Prerequisites:
 
@@ -45,7 +56,8 @@ mvn clean package -DskipTests
 ```
 
 The resulting jars can be found in the `target` directory of the respective
-module.
+module. The connector library JAR file is
+`flink-connector-gcp-pubsub/target/flink-connector-gcp-pubsub-0.0.0.jar`.
 
 Flink applications built with Maven can include the connector as a dependency in
 their pom.xml file by adding:
@@ -61,8 +73,206 @@ their pom.xml file by adding:
 Learn more about Flink connector packaging
 [here](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/configuration/overview/).
 
-## Documentation
+## Quickstart
 
-The documentation of Apache Flink is located on the website:
-[https://flink.apache.org](https://flink.apache.org) or in the `docs/`
-directory.
+This section describes how to build the example Flink job located under
+`flink-examples-gcp-pubsub/`, deploy it to a Flink cluster, and verify that it
+is running correctly. The example job streams data from a Pub/Sub subscription
+source and publishes that data to a Pub/Sub topic sink.
+
+### Prerequisites
+
+1.  Flink cluster
+
+    Flink's
+    [first steps guide](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/try-flink/local_installation/)
+    describes how to download Flink and start a local-running Flink cluster to
+    which you can deploy the example Flink job.
+
+2.  [GCP project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
+    in which you can create
+    [Pub/Sub topics](https://cloud.google.com/pubsub/docs/create-topic) and
+    [Pub/Sub subscriptions](https://cloud.google.com/pubsub/docs/create-subscription)
+
+3.  [OPTIONAL] `gcloud` CLI
+    ([installation instructions](https://cloud.google.com/sdk/docs/install))
+
+    For your convenience, this section includes `gcloud` commands that you can
+    run to complete certain steps. These steps can also be completed using the
+    [GCP console UI](https://cloud.google.com/cloud-console) or using one of the
+    [Pub/Sub client libraries](https://cloud.google.com/pubsub/docs/reference/libraries).
+
+### Building the Example
+
+Flink jobs are typically packaged into a JAR file with their dependencies. The
+following commands use Maven to build and package the example Flink job into a
+JAR file that will be deployed to run on a Flink cluster.
+
+```sh
+# If you haven't already done so, download this repository.
+git clone https://github.com/GoogleCloudPlatform/pubsub.git
+cd pubsub/flink-connector
+
+# Run this command in the same directory as this README file.
+mvn clean package -DskipTests
+```
+
+Running these commands should result in the creation of
+`flink-examples-gcp-pubsub/pubsub-streaming/target/PubSubExample.jar`.
+
+### Creating Pub/Sub Topics and Subscriptions
+
+We will use 2 Pub/Sub topics and 2 Pub/Sub subscriptions to run and verify the
+example Flink job. The following steps describe how we will use them to validate
+data flows through Pub/Sub and the example Flink job as expected.
+
+1.  We manually publish a message to `SOURCE_TOPIC`
+2.  Pub/Sub makes the message available for delivery on `SOURCE_SUBSCRIPTION`
+    (attached to `SOURCE_TOPIC`)
+3.  Flink job pulls the message from `SOURCE_SUBSCRIPTION`
+4.  Flink job publishes the message to `SINK_TOPIC`
+5.  Pub/Sub makes the message available for delivery on `SINK_SUBSCRIPTION`
+    (attached to `SINK_TOPIC`)
+6.  We manually pull the message from `SINK_SUBSCRIPTION`, confirming that the
+    Flink job successfully used Pub/Sub as both a source and sink
+
+The following commands set variables for your GCP project name, Pub/Sub topic
+names, and Pub/Sub subcription names. These variables are referenced in this
+section's commands. The placeholder value for `PROJECT_NAME` must be updated to
+your GCP project name. The other placeholder values can be used as is or updated
+to your liking.
+
+```sh
+# This value must be updated to your GCP project name!
+export PROJECT_NAME={YOUR-GCP-PROJECT-NAME}
+
+# SOURCE_SUBSCRIPTION is attached to SOURCE_TOPIC
+export SOURCE_TOPIC=flink-example-source-topic
+export SOURCE_SUBSCRIPTION=flink-example-source-subscription
+
+# SINK_SUBSCRIPTION is attached to SINK_TOPIC
+export SINK_TOPIC=flink-example-sink-topic
+export SINK_SUBSCRIPTION=flink-example-sink-subscription
+```
+
+Create the [topics](https://cloud.google.com/pubsub/docs/create-topic) and
+[subscriptions](https://cloud.google.com/pubsub/docs/create-subscription).
+
+```sh
+gcloud pubsub topics create $SOURCE_TOPIC --project=$PROJECT_NAME
+gcloud pubsub topics create $SINK_TOPIC --project=$PROJECT_NAME
+gcloud pubsub subscriptions create $SOURCE_SUBSCRIPTION --topic=$SOURCE_TOPIC --project=$PROJECT_NAME
+gcloud pubsub subscriptions create $SINK_SUBSCRIPTION --topic=$SINK_TOPIC --project=$PROJECT_NAME
+```
+
+### Accessing Pub/Sub from a Flink Job
+
+1.  Credentials
+
+Requests sent to Google Cloud Pub/Sub must be
+[authenticated](https://cloud.google.com/pubsub/docs/authentication). By
+default, the connector library authenticates requests using
+[Application Default Credentials](https://cloud.google.com/docs/authentication#adc)
+(ADC). We recommend setting up ADC in your Flink cluster, if possible, to avoid
+having to make changes to the example Flink job.
+
+If your Flink cluster runs on GCP resources (e.g., Google Computer Engine,
+Google Kubernetes Engine), ADC is likely already configured to authenticate as a
+[service account](https://cloud.google.com/iam/docs/service-account-overview).
+
+To configure ADC in your Flink cluster, follow these
+[instructions](https://cloud.google.com/docs/authentication/provide-credentials-adc).
+See this
+[troubleshooting guide](https://cloud.google.com/docs/authentication/troubleshoot-adc)
+if you are having issues with configuring ADC.
+
+If you cannot authenticate using ADC, see this
+[section](https://github.com/GoogleCloudPlatform/pubsub/blob/master/flink-connector/docs/content/docs/connectors/datastream/pubsub.md#configuring-access-to-google-cloud-pubsub)
+on how to manually set credentials. You will need to make these changes to
+`PubSubExample.java` and rebuild the example Flink job JAR file.
+
+1.  Authorization
+
+The authenticated account must have
+[permission](https://cloud.google.com/pubsub/docs/access-control) to
+[publish messages](https://cloud.google.com/pubsub/docs/access-control#pubsub.publisher)
+to `SINK_TOPIC` and
+[pull messages](https://cloud.google.com/pubsub/docs/access-control#pubsub.subscriber)
+from `SOURCE_SUBSCRIPTION`. These permissions are controlled through IAM
+policies, which can be
+[set](https://cloud.google.com/pubsub/docs/access-control#setting_a_policy) and
+[tested](https://cloud.google.com/pubsub/docs/access-control#testing_permissions)
+through the `gcloud` CLI.
+
+### Running and Verifying the Example Flink Job
+
+Start the Flink job.
+
+```sh
+# Run this command in the same directory as this README file.
+flink run ./flink-examples-gcp-pubsub/pubsub-streaming/target/PubSubExample.jar \
+  --project $PROJECT_NAME \
+  --source-subscription $SOURCE_SUBSCRIPTION \
+  --sink-topic $SINK_TOPIC
+```
+
+If successful, the command should output something like: `Job has been submitted
+with JobID ...`.
+
+[Publish a message](https://cloud.google.com/pubsub/docs/publisher#publish-messages)
+to `SOURCE_TOPIC`.
+
+```sh
+gcloud pubsub topics publish projects/$PROJECT_NAME/topics/$SOURCE_TOPIC --message="Hello!"
+```
+
+The running Flink job will pull the published message from `SOURCE_SUBSCRIPTION`
+and publish it to `SINK_TOPIC`. You can verify this by trying to pull the
+message from `SINK_SUBSCRIPTION`.
+
+```sh
+# The flag --auto-ack causes pulled messages to be acknowledged, so they will
+# not be redelivered if you run this command again.
+gcloud pubsub subscriptions pull projects/$PROJECT_NAME/subscriptions/$SINK_SUBSCRIPTION --auto-ack
+```
+
+If you are unable to pull the message you published, then follow these steps to
+debug your issue and try again after restarting the job.
+
+1.  Use Flink's web UI to help debug the issue. Check the status of the example
+    job and cluster logs for errors.
+2.  Verify your Pub/Sub topic and subscription configurations. If they are
+    configured properly, you should be able to manually publish messages to both
+    topics and manually pull messages from both subscriptions. Test this using
+    unique message contents so that you can also confirm to which topic each
+    subscription is attached.
+3.  Run an
+    [example job bundled with Flink](https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/try-flink/local_installation/#submitting-a-flink-job)
+    to test whether your Flink cluster is working correctly.
+4.  Ensure that your Flink cluster set up ADC correctly and that the
+    authenticating account has permission to pull from `SOURCE_SUBSCRIPTION` and
+    publish to `SINK_TOPIC`.
+
+If you are able to pull the message that you published earlier, then you have
+successfully ran a Flink job that uses the Pub/Sub connector library!
+
+To learn about using this library in your own Flink job, check out
+[`docs/content/docs/connectors/datastream/pubsub.md`](https://github.com/GoogleCloudPlatform/pubsub/blob/master/flink-connector/docs/content/docs/connectors/datastream/pubsub.md).
+
+### Cleaning Up
+
+Delete Pub/Sub [topics](https://cloud.google.com/pubsub/docs/delete-topic) and
+[subscriptions](https://cloud.google.com/pubsub/docs/delete-subscriptions).
+
+```sh
+gcloud pubsub topics delete $SOURCE_TOPIC --project=$PROJECT_NAME
+gcloud pubsub topics delete $SINK_TOPIC --project=$PROJECT_NAME
+gcloud pubsub subscriptions delete $SOURCE_SUBSCRIPTION --project=$PROJECT_NAME
+gcloud pubsub subscriptions delete $SINK_SUBSCRIPTION --project=$PROJECT_NAME
+```
+
+Stop the example Flink job.
+
+```sh
+flink cancel {Flink JobID output when it started}
+```

--- a/flink-connector/README.md
+++ b/flink-connector/README.md
@@ -57,7 +57,7 @@ mvn clean package -DskipTests
 
 The resulting jars can be found in the `target` directory of the respective
 module. The connector library JAR file is
-`flink-connector-gcp-pubsub/target/flink-connector-gcp-pubsub-0.0.0.jar`.
+`flink-connector-gcp-pubsub/target/flink-connector-gcp-pubsub-1.0.0-SNAPSHOT.jar`.
 
 Flink applications built with Maven can include the connector as a dependency in
 their pom.xml file by adding:
@@ -66,7 +66,7 @@ their pom.xml file by adding:
 <dependency>
   <groupId>com.google.pubsub.flink</groupId>
   <artifactId>flink-connector-gcp-pubsub</artifactId>
-  <version>0.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
+++ b/flink-connector/docs/content/docs/connectors/datastream/pubsub.md
@@ -31,7 +31,7 @@ their pom.xml file by adding:
 <dependency>
   <groupId>com.google.pubsub.flink</groupId>
   <artifactId>flink-connector-gcp-pubsub</artifactId>
-  <version>0.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/flink-connector/flink-connector-gcp-pubsub-e2e-tests/pom.xml
+++ b/flink-connector/flink-connector-gcp-pubsub-e2e-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.pubsub.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>0.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flink-connector-gcp-pubsub-e2e-tests</artifactId>

--- a/flink-connector/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector/flink-connector-gcp-pubsub/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.pubsub.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>0.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.google.pubsub.flink</groupId>

--- a/flink-connector/flink-examples-gcp-pubsub/pom.xml
+++ b/flink-connector/flink-examples-gcp-pubsub/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.pubsub.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>0.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flink-examples-gcp-pubsub</artifactId>

--- a/flink-connector/flink-examples-gcp-pubsub/pubsub-streaming/pom.xml
+++ b/flink-connector/flink-examples-gcp-pubsub/pubsub-streaming/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.pubsub.flink</groupId>
     <artifactId>flink-examples-gcp-pubsub</artifactId>
-    <version>0.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Pub/Sub Flink Streaming Connector Example</name>

--- a/flink-connector/flink-examples-gcp-pubsub/pubsub-streaming/src/main/java/com/google/pubsub/flink/PubSubExample.java
+++ b/flink-connector/flink-examples-gcp-pubsub/pubsub-streaming/src/main/java/com/google/pubsub/flink/PubSubExample.java
@@ -16,6 +16,8 @@
 
 package com.google.pubsub.flink;
 
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -28,32 +30,63 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
  * <p>This job pulls messages from a PubSub subscription as a data source and publishes these
  * messages to a PubSub topic as a sink.
  *
- * <p>Example usage: --project project-name --subscription source-subscription --topic sink-topic
+ * <p>Example usage (source subscription and sink topic must be in the same GCP project): $ flink
+ * run PubSubExample.jar --project PROJECT-NAME --source-subscription SUBSCRIPTION-NAME --sink-topic
+ * TOPIC-NAME
+ *
+ * <p>Example usage (source subscription and sink topic can be in different GCP projects): $ flink
+ * run PubSubExample.jar --source-subscription projects/PROJECT-NAME/subscriptions/SUBSCRIPTION-NAME
+ * --sink-topic projects/PROJECT-NAME/topics/TOPIC-NAME
  */
 public class PubSubExample {
 
   public static void main(String[] args) throws Exception {
     final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-    // Parse input parameters.
     final ParameterTool parameterTool = ParameterTool.fromArgs(args);
-    if (parameterTool.getNumberOfParameters() != 3) {
+    // Parse sink topic from parameters.
+    String topicName = parameterTool.get("sink-topic");
+    String topicProject = parameterTool.get("project");
+    if (topicName == null) {
+      System.out.println("Failed to start! The parameter --sink-topic must be specified.");
+    }
+    if (ProjectTopicName.isParsableFrom(topicName)) {
+      ProjectTopicName projectTopicName = ProjectTopicName.parse(topicName);
+      topicName = projectTopicName.getTopic();
+      topicProject = projectTopicName.getProject();
+    }
+    if (topicProject == null) {
       System.out.println(
-          "Missing parameters!\n"
-              + "Usage: flink run PubSubExample.jar --project <GCP project name>"
-              + " --subscription <subscription> --topic <topic>");
+          "Failed to start! The sink topic project must be specified using either [--project"
+              + " PROJECT-NAME] or [--sink-topic projects/PROJECT-NAME/topics/TOPIC-NAME].");
       return;
     }
-    String projectName = parameterTool.getRequired("project");
-    String subscription = parameterTool.getRequired("subscription");
-    String topic = parameterTool.getRequired("topic");
+    // Parse source subscription from parameters.
+    String subscriptionName = parameterTool.get("source-subscription");
+    String subscriptionProject = parameterTool.get("project");
+    if (subscriptionName == null) {
+      System.out.println("Failed to start! The parameter --source-subscription must be specified.");
+    }
+    if (ProjectSubscriptionName.isParsableFrom(subscriptionName)) {
+      ProjectSubscriptionName projectSubscriptionName =
+          ProjectSubscriptionName.parse(subscriptionName);
+      subscriptionName = projectSubscriptionName.getSubscription();
+      subscriptionProject = projectSubscriptionName.getProject();
+    }
+    if (subscriptionProject == null) {
+      System.out.println(
+          "Failed to start! The source subscription project must be specified using either"
+              + " [--project PROJECT-NAME] or [--source-subscription"
+              + " projects/PROJECT-NAME/subscriptions/SUBSCRIPTION-NAME].");
+      return;
+    }
 
     DataStream<String> stream =
         env.fromSource(
             PubSubSource.<String>builder()
                 .setDeserializationSchema(
                     PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()))
-                .setProjectName(projectName)
-                .setSubscriptionName(subscription)
+                .setProjectName(subscriptionProject)
+                .setSubscriptionName(subscriptionName)
                 .build(),
             WatermarkStrategy.noWatermarks(),
             "PubSubSource");
@@ -62,8 +95,8 @@ public class PubSubExample {
             PubSubSink.<String>builder()
                 .setSerializationSchema(
                     PubSubSerializationSchema.dataOnly(new SimpleStringSchema()))
-                .setProjectName(projectName)
-                .setTopicName(topic)
+                .setProjectName(topicProject)
+                .setTopicName(topicName)
                 .build())
         .name("PubSubSink");
 

--- a/flink-connector/pom.xml
+++ b/flink-connector/pom.xml
@@ -7,7 +7,7 @@
   <packaging>pom</packaging>
   <name>Pub/Sub Flink Connector Parent</name>
   <artifactId>flink-connector-parent</artifactId>
-  <version>0.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <modules>
     <module>flink-connector-gcp-pubsub</module>
     <module>flink-examples-gcp-pubsub</module>


### PR DESCRIPTION
- Make the example parameters more clear
- Add parsing for fully-qualified topic/subscription names
- Add a quickstart guide in the README for building, running, and verifying the example job
- Add more code samples to pubsub.md (more to come)