### PR TITLE
Do not add source messages to a checkpoint until after it is emitted

### DIFF
--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSource.java
@@ -31,8 +31,8 @@ import com.google.common.base.Preconditions;
 import com.google.pubsub.flink.internal.source.enumerator.PubSubCheckpointSerializer;
 import com.google.pubsub.flink.internal.source.enumerator.PubSubSplitEnumerator;
 import com.google.pubsub.flink.internal.source.reader.AckTracker;
+import com.google.pubsub.flink.internal.source.reader.PubSubAckTracker;
 import com.google.pubsub.flink.internal.source.reader.PubSubNotifyingPullSubscriber;
-import com.google.pubsub.flink.internal.source.reader.PubSubRecordEmitter;
 import com.google.pubsub.flink.internal.source.reader.PubSubSourceReader;
 import com.google.pubsub.flink.internal.source.reader.PubSubSplitReader;
 import com.google.pubsub.flink.internal.source.split.SubscriptionSplit;
@@ -156,7 +156,8 @@ public abstract class PubSubSource<OutputT>
           }
         });
     return new PubSubSourceReader<>(
-        new PubSubRecordEmitter<>(schema),
+        schema,
+        new PubSubAckTracker(),
         this::createSplitReader,
         new Configuration(),
         readerContext);

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/AckTracker.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/AckTracker.java
@@ -17,12 +17,38 @@ package com.google.pubsub.flink.internal.source.reader;
 
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 
+/** This class tracks the lifecycle of messages in {@link PubSubSource}. */
 public interface AckTracker {
-  void addPendingAck(AckReplyConsumer ackReplyConsumer);
+  /**
+   * Track a new pending ack. Acks are pending when a message has been received but not yet
+   * processed by the Flink pipeline.
+   *
+   * <p>If there is already a pending ack for {@code messageId}, the existing ack is replaced.
+   */
+  void addPendingAck(String messageId, AckReplyConsumer ackReplyConsumer);
 
+  /**
+   * Stage a pending ack for the next checkpoint snapshot. Staged acks indicate that a message has
+   * been emitted to the Flink pipeline and should be included in the next checkpoint.
+   */
+  void stagePendingAck(String messageId);
+
+  /**
+   * Prepare all staged acks to be acknowledged to Google Cloud Pub/Sub when checkpoint {@code
+   * checkpointId} completes.
+   */
   void addCheckpoint(long checkpointId);
 
+  /**
+   * Acknowledge all staged acks in checkpoint {@code checkpointId} and stop tracking them in this
+   * {@link AckTracker}.
+   */
   void notifyCheckpointComplete(long checkpointId);
 
+  /**
+   * Negatively acknowledge (nack) and stop tracking all acks currently tracked by this {@link
+   * AckTracker}. Nacked messages are eligible for redelivery by Google Cloud Pub/Sub before the
+   * message's ack deadline expires.
+   */
   void nackAll();
 }

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/PubSubSourceReader.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/internal/source/reader/PubSubSourceReader.java
@@ -16,6 +16,7 @@
 package com.google.pubsub.flink.internal.source.reader;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.pubsub.flink.PubSubDeserializationSchema;
 import com.google.pubsub.flink.internal.source.split.SubscriptionSplit;
 import com.google.pubsub.flink.internal.source.split.SubscriptionSplitState;
 import com.google.pubsub.v1.PubsubMessage;
@@ -36,23 +37,18 @@ public class PubSubSourceReader<T>
 
   private final AckTracker ackTracker;
 
-  @VisibleForTesting
-  PubSubSourceReader(
-      RecordEmitter<PubsubMessage, T, SubscriptionSplitState> recordEmitter,
-      SplitReaderFactory splitReaderFactory,
-      Configuration config,
-      SourceReaderContext context,
-      AckTracker ackTracker) {
-    super(() -> splitReaderFactory.create(ackTracker), recordEmitter, config, context);
-    this.ackTracker = ackTracker;
-  }
-
   public PubSubSourceReader(
-      RecordEmitter<PubsubMessage, T, SubscriptionSplitState> recordEmitter,
+      PubSubDeserializationSchema<T> schema,
+      AckTracker ackTracker,
       SplitReaderFactory splitReaderFactory,
       Configuration config,
       SourceReaderContext context) {
-    this(recordEmitter, splitReaderFactory, config, context, new PubSubAckTracker());
+    super(
+        () -> splitReaderFactory.create(ackTracker),
+        new PubSubRecordEmitter<>(schema, ackTracker),
+        config,
+        context);
+    this.ackTracker = ackTracker;
   }
 
   @Override

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTrackerTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubAckTrackerTest.java
@@ -16,6 +16,7 @@
 package com.google.pubsub.flink.internal.source.reader;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
@@ -36,18 +37,35 @@ public class PubSubAckTrackerTest {
   @Test
   public void singleAck_ackedOnCheckpoint() throws Exception {
     AckReplyConsumer mockAck = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck);
+    ackTracker.addPendingAck("message-id", mockAck);
+    ackTracker.stagePendingAck("message-id");
     ackTracker.addCheckpoint(1L);
     ackTracker.notifyCheckpointComplete(1L);
     verify(mockAck).ack();
   }
 
   @Test
+  public void singleAck_ackLatestMessageDelivery() throws Exception {
+    AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
+    ackTracker.addPendingAck("message-id", mockAck1);
+    AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
+    ackTracker.addPendingAck("message-id", mockAck2);
+
+    ackTracker.stagePendingAck("message-id");
+    ackTracker.addCheckpoint(1L);
+    ackTracker.notifyCheckpointComplete(1L);
+    verify(mockAck1, times(0)).ack();
+    verify(mockAck2, times(1)).ack();
+  }
+
+  @Test
   public void manyAcks_ackedOnCheckpoint() throws Exception {
     AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck1);
+    ackTracker.addPendingAck("message1-id", mockAck1);
+    ackTracker.stagePendingAck("message1-id");
     AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck2);
+    ackTracker.addPendingAck("message2-id", mockAck2);
+    ackTracker.stagePendingAck("message2-id");
     ackTracker.addCheckpoint(1L);
     ackTracker.notifyCheckpointComplete(1L);
     verify(mockAck1).ack();
@@ -57,28 +75,34 @@ public class PubSubAckTrackerTest {
   @Test
   public void manyCheckpoints_completedOneByOne() throws Exception {
     AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck1);
+    ackTracker.addPendingAck("message1-id", mockAck1);
+    ackTracker.stagePendingAck("message1-id");
     ackTracker.addCheckpoint(1L);
 
     AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck2);
+    ackTracker.addPendingAck("message2-id", mockAck2);
+    ackTracker.stagePendingAck("message2-id");
     ackTracker.addCheckpoint(2L);
 
     ackTracker.notifyCheckpointComplete(1L);
-    verify(mockAck1).ack();
+    verify(mockAck1, times(1)).ack();
+    verify(mockAck2, times(0)).ack();
 
     ackTracker.notifyCheckpointComplete(2L);
-    verify(mockAck2).ack();
+    verify(mockAck1, times(1)).ack();
+    verify(mockAck2, times(1)).ack();
   }
 
   @Test
   public void manyCheckpoints_completedTogether() throws Exception {
     AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck1);
+    ackTracker.addPendingAck("message1-id", mockAck1);
+    ackTracker.stagePendingAck("message1-id");
     ackTracker.addCheckpoint(1L);
 
     AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck2);
+    ackTracker.addPendingAck("message2-id", mockAck2);
+    ackTracker.stagePendingAck("message2-id");
     ackTracker.addCheckpoint(2L);
 
     ackTracker.notifyCheckpointComplete(2L);
@@ -87,16 +111,24 @@ public class PubSubAckTrackerTest {
   }
 
   @Test
-  public void nackAll_pendingAndIncompleteCheckpointAcks() throws Exception {
+  public void nackAll_pendingStagedAndIncompleteCheckpointAcks() throws Exception {
+    // mockAck1 is added to checkpoint 1, which never completes.
     AckReplyConsumer mockAck1 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck1);
+    ackTracker.addPendingAck("message1-id", mockAck1);
+    ackTracker.stagePendingAck("message1-id");
     ackTracker.addCheckpoint(1L);
+    // mockAck2 is staged.
     AckReplyConsumer mockAck2 = mock(AckReplyConsumer.class);
-    ackTracker.addPendingAck(mockAck2);
+    ackTracker.addPendingAck("message2-id", mockAck2);
+    ackTracker.stagePendingAck("message2-id");
+    // mockAck3 is pending.
+    AckReplyConsumer mockAck3 = mock(AckReplyConsumer.class);
+    ackTracker.addPendingAck("message3-id", mockAck3);
 
     ackTracker.nackAll();
 
     verify(mockAck1).nack();
     verify(mockAck2).nack();
+    verify(mockAck3).nack();
   }
 }

--- a/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubSourceReaderTest.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/test/java/com/google/pubsub/flink/internal/source/reader/PubSubSourceReaderTest.java
@@ -58,14 +58,13 @@ public class PubSubSourceReaderTest {
   public void doBeforeEachTest() throws Exception {
     reader =
         new PubSubSourceReader<>(
-            new PubSubRecordEmitter<String>(
-                PubSubDeserializationSchema.dataOnly(new SimpleStringSchema())),
+            PubSubDeserializationSchema.dataOnly(new SimpleStringSchema()),
+            mockAckTracker,
             (ackTracker) -> {
               return mockSplitReader;
             },
             new Configuration(),
-            mockContext,
-            mockAckTracker);
+            mockContext);
   }
 
   @Test


### PR DESCRIPTION
This PR is a follow-up to https://github.com/GoogleCloudPlatform/pubsub/pull/362, which deferred the call to `AckTracker.addPendingAck` until the message was fetched. That change is insufficient to guarantee at-least-once delivery, since this race condition is possible:

1. A message is fetched and added to `SourceReaderBase.elementsQueue` (the message's ack is pending)
2. `SourceReaderBase.snapshotState` is called, which calls `AckTracker.addCheckpoint(checkpointId)` (the message is added to `checkpointId` before calling `RecordEmitter.emitRecord` with the message)
3. `SourceReaderBase.notifyCheckpointComplete` is called, which calls `AckTracker.notifyCheckpointComplete` to ack the message (there's no guarantee that `RecordEmitter.emitRecord` was called before acking the message)
4. The Flink pipeline crashes (no guarantee that the message was processed by the sink)

The fix is not adding messages to `PubSubAckTracker.checkpoints` until after they are emitted (it's idiomatic to update the state of records in `RecordEmitter.emitRecord`). This PR also reverts some of the changes made to `PubSubNotifyingPullSubscriber` in https://github.com/GoogleCloudPlatform/pubsub/pull/362, since it's safe to add pending acks to `AckTracker` on message delivery because they are not added to a checkpoint until the message is emitted.

Note that there is almost no delay between fetching a message and calling `RecordEmitter.emitRecord`, so I have not been able to reproduce this. This is likely a rare race condition to trigger, since the timing is very tight to reproduce the described state and impact only manifests if the Flink application fails.