### PR TITLE
Replace ordering key prober's --should_cleanup with --should_not_cleanup so that we can use the flag

### DIFF
--- a/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
+++ b/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
@@ -40,7 +40,7 @@ public class ProberStarter {
     @Parameter(names = "--endpoint", description = "Cloud Pub/Sub endpoint to run against.")
     private String endpoint = "pubsub.googleapis.com:443";
 
-    @Parameter(names = "--should_not_cleanup", description = "Whether the prober should start by not cleaning up the topic and subscription.")
+    @Parameter(names = "--no_cleanup", description = "Skip the cleanup of the topic and subscription on startup.")
     private boolean shouldNotCleanup = false;
 
     @Parameter(names = "--no_publish", description ="Whether the prober should skip publishing.")

--- a/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
+++ b/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
@@ -40,8 +40,8 @@ public class ProberStarter {
     @Parameter(names = "--endpoint", description = "Cloud Pub/Sub endpoint to run against.")
     private String endpoint = "pubsub.googleapis.com:443";
 
-    @Parameter(names = "--should_cleanup", description ="Whether the prober should start by cleaning up the topic and subscription.")
-    private boolean shouldCleanup = true;
+    @Parameter(names = "--should_not_cleanup", description = "Whether the prober should start by not cleaning up the topic and subscription.")
+    private boolean shouldNotCleanup = false;
 
     @Parameter(names = "--no_publish", description ="Whether the prober should skip publishing.")
     private boolean noPublish = false;
@@ -176,7 +176,7 @@ public class ProberStarter {
     builder
         .setProject(parsedArgs.project)
         .setEndpoint(parsedArgs.endpoint)
-        .setShouldCleanup(parsedArgs.shouldCleanup)
+        .setShouldCleanup(!parsedArgs.shouldNotCleanup)
         .setNoPublish(parsedArgs.noPublish)
         .setTopicName(parsedArgs.topicName)
         .setSubscriptionName(parsedArgs.subscriptionName)

--- a/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
+++ b/ordering-keys-prober/src/main/java/com/google/cloud/pubsub/prober/ProberStarter.java
@@ -41,7 +41,7 @@ public class ProberStarter {
     private String endpoint = "pubsub.googleapis.com:443";
 
     @Parameter(names = "--no_cleanup", description = "Skip the cleanup of the topic and subscription on startup.")
-    private boolean shouldNotCleanup = false;
+    private boolean noCleanup = false;
 
     @Parameter(names = "--no_publish", description ="Whether the prober should skip publishing.")
     private boolean noPublish = false;
@@ -176,7 +176,7 @@ public class ProberStarter {
     builder
         .setProject(parsedArgs.project)
         .setEndpoint(parsedArgs.endpoint)
-        .setShouldCleanup(!parsedArgs.shouldNotCleanup)
+        .setShouldCleanup(!parsedArgs.noCleanup)
         .setNoPublish(parsedArgs.noPublish)
         .setTopicName(parsedArgs.topicName)
         .setSubscriptionName(parsedArgs.subscriptionName)


### PR DESCRIPTION
The current implementation will not be able to disable the flag (i.e., specify that I don't want to cleanup). This can be resolved by adding `arity=1` in the @parameter() (see https://jcommander.org/ section 2.1), but I try to keep the style consistent with `--no_publish` flag, I decide to just introduce the negation in the flag name.