### PR TITLE
Upgrade Flink connector to Flink 2.2 and Java 17

### DIFF
--- a/flink-connector/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector/flink-connector-gcp-pubsub/pom.xml
@@ -39,7 +39,7 @@
         </executions>
         <configuration>
           <protocArtifact>
-            com.google.protobuf:protoc:3.4.0:exe:${os.detected.classifier}
+            com.google.protobuf:protoc:3.25.3:exe:${os.detected.classifier}
           </protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>

--- a/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
+++ b/flink-connector/flink-connector-gcp-pubsub/src/main/java/com/google/pubsub/flink/PubSubSink.java
@@ -34,6 +34,7 @@ import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 
 /**
  * Google Cloud Pub/Sub sink to publish messages to a Pub/Sub topic.
@@ -92,7 +93,7 @@ public abstract class PubSubSink<T> implements Sink<T> {
   }
 
   @Override
-  public SinkWriter<T> createWriter(InitContext initContext) throws IOException {
+  public SinkWriter<T> createWriter(WriterInitContext initContext) throws IOException {
     try {
       serializationSchema().open(initContext.asSerializationSchemaInitializationContext());
     } catch (Exception e) {

--- a/flink-connector/pom.xml
+++ b/flink-connector/pom.xml
@@ -13,10 +13,10 @@
   </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>11</java.version>
-    <flink.version>1.17.2</flink.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <java.version>17</java.version>
+    <flink.version>2.2.0</flink.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <auto-value.version>1.11.0</auto-value.version>
   </properties>
 


### PR DESCRIPTION
## Summary

Minimal upgrade to support Apache Flink 2.2 and Java 17:

- `flink-connector/pom.xml`: bump Flink 1.17.2 → 2.2.0, Java 11 → 17
- `flink-connector-gcp-pubsub/pom.xml`: bump protoc 3.4.0 → 3.25.3
  (required for Flink 2.2 compatibility)
- `PubSubSink.java`: update `createWriter` signature from `InitContext`
  to `WriterInitContext` (API change in Flink 2.x / FLIP-143)

## Motivation

Flink 2.x renamed `Sink.InitContext` to `WriterInitContext` as part of
the FLIP-143 unified sink API. Without this change the connector fails
to compile against Flink 2.2+.

This was validated end-to-end on GCP Dataproc 3.0 (Flink 2.2.0,
Java 17) consuming real Pub/Sub topics in a streaming pipeline
(cross-project subscriptions).

## Testing

- Compiled and ran against Flink 2.2.0 on Dataproc 3.0-debian13
- Streaming job processed messages from Pub/Sub cross-project
  subscriptions successfully with `PubSubSource` (FLIP-27) and
  `PubSubSink` (FLIP-143)
- All existing tests pass
